### PR TITLE
Add API filters for athlete result history

### DIFF
--- a/src/Entity/Competition/Athlete.php
+++ b/src/Entity/Competition/Athlete.php
@@ -2,6 +2,8 @@
 
 namespace App\Entity\Competition;
 
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -16,6 +18,13 @@ use Symfony\Component\Uid\Uuid;
 #[ORM\Table(name: 'athlete')]
 #[ORM\UniqueConstraint(name: 'UNIQ_ATHLETE_SOURCE_EXTERNAL', columns: ['source_name', 'external_id'])]
 #[ApiResource(operations: [new Get(), new GetCollection()])]
+#[ApiFilter(SearchFilter::class, properties: [
+    'displayName' => 'ipartial',
+    'firstName' => 'ipartial',
+    'lastName' => 'ipartial',
+    'sourceName' => 'exact',
+    'externalId' => 'exact',
+])]
 class Athlete
 {
     #[ORM\Id]

--- a/src/Entity/Competition/WorkoutResult.php
+++ b/src/Entity/Competition/WorkoutResult.php
@@ -2,6 +2,9 @@
 
 namespace App\Entity\Competition;
 
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -12,6 +15,17 @@ use Symfony\Component\Uid\Uuid;
 #[ORM\Table(name: 'workout_result')]
 #[ORM\UniqueConstraint(name: 'UNIQ_WORKOUT_RESULT_SOURCE_EXTERNAL', columns: ['source_name', 'external_id'])]
 #[ApiResource(operations: [new Get(), new GetCollection()])]
+#[ApiFilter(SearchFilter::class, properties: [
+    'athlete' => 'exact',
+    'event' => 'exact',
+    'event.competition' => 'exact',
+    'competitionDivision' => 'exact',
+    'division' => 'ipartial',
+    'sourceName' => 'exact',
+    'externalId' => 'exact',
+    'rank' => 'exact',
+])]
+#[ApiFilter(OrderFilter::class, properties: ['rank', 'points', 'createdAt', 'updatedAt'])]
 class WorkoutResult
 {
     #[ORM\Id]

--- a/src/Entity/Workout/Workout.php
+++ b/src/Entity/Workout/Workout.php
@@ -2,6 +2,9 @@
 
 namespace App\Entity\Workout;
 
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -15,6 +18,13 @@ use Symfony\Component\Uid\Uuid;
 #[ORM\Entity(repositoryClass: WorkoutRepository::class)]
 #[ORM\UniqueConstraint(name: 'UNIQ_WORKOUT_SOURCE_EXTERNAL', columns: ['source_name', 'external_id'])]
 #[ApiResource(operations: [new Get(), new GetCollection()])]
+#[ApiFilter(SearchFilter::class, properties: [
+    'name' => 'ipartial',
+    'flow' => 'ipartial',
+    'sourceName' => 'exact',
+    'externalId' => 'exact',
+])]
+#[ApiFilter(OrderFilter::class, properties: ['name', 'createdAt'])]
 class Workout
 {
     #[ORM\Id]

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -2,6 +2,14 @@
 
 namespace App\Tests;
 
+use App\Entity\Competition\Athlete;
+use App\Entity\Competition\Competition;
+use App\Entity\Competition\CompetitionDivision;
+use App\Entity\Competition\CompetitionEvent;
+use App\Entity\Competition\Enum\ScoreTypeEnum;
+use App\Entity\Competition\Score;
+use App\Entity\Competition\WorkoutResult;
+
 class WorkoutApiWorkflowTest extends AbstractIntegrationTest
 {
     public function testFrontendCanListWorkoutCatalogFromApi(): void
@@ -28,6 +36,57 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         $athletes = $payload['member'] ?? $payload['hydra:member'] ?? null;
 
         self::assertIsArray($athletes);
+    }
+
+    public function testFrontendCanSearchAthletesByDisplayName(): void
+    {
+        $entityManager = $this->getEntityManager();
+        $entityManager->persist(new Athlete('Tia-Clair Toomey', 'crossfit_games', 'tia-toomey'));
+        $entityManager->persist(new Athlete('Mat Fraser', 'crossfit_games', 'mat-fraser'));
+        $entityManager->flush();
+
+        $this->browser()->request('GET', '/api/athletes?displayName=tia');
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $athletes = $payload['member'] ?? $payload['hydra:member'] ?? [];
+        $names = array_map(static fn (array $athlete): ?string => $athlete['displayName'] ?? null, $athletes);
+
+        self::assertContains('Tia-Clair Toomey', $names);
+        self::assertNotContains('Mat Fraser', $names);
+    }
+
+    public function testFrontendCanFilterWorkoutResultsByAthleteIri(): void
+    {
+        $entityManager = $this->getEntityManager();
+        $tia = new Athlete('Tia-Clair Toomey', 'crossfit_games', 'tia-toomey-results');
+        $mat = new Athlete('Mat Fraser', 'crossfit_games', 'mat-fraser-results');
+        $competition = (new Competition('CrossFit Games', 'crossfit_games', 'games-2017'))
+            ->setSeason(2017);
+        $event = new CompetitionEvent($competition, '17.5', 'crossfit_games', 'games-2017-17-5');
+        $division = new CompetitionDivision($competition, 'Women', 'crossfit_games', 'games-2017-women');
+        $tiaResult = (new WorkoutResult($tia, $event, new Score(ScoreTypeEnum::TIME, '6:35'), 'crossfit_games', 'tia-17-5'))
+            ->setCompetitionDivision($division)
+            ->setRank(1);
+        $matResult = (new WorkoutResult($mat, $event, new Score(ScoreTypeEnum::TIME, '6:24'), 'crossfit_games', 'mat-17-5'))
+            ->setRank(1);
+
+        foreach ([$tia, $mat, $competition, $event, $division, $tiaResult, $matResult] as $entity) {
+            $entityManager->persist($entity);
+        }
+        $entityManager->flush();
+
+        $this->browser()->request('GET', sprintf('/api/workout_results?athlete=/api/athletes/%s', $tia->getId()));
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $results = $payload['member'] ?? $payload['hydra:member'] ?? [];
+
+        self::assertCount(1, $results);
+        self::assertSame('/api/athletes/'.$tia->getId(), $results[0]['athlete']);
+        self::assertSame(1, $results[0]['rank']);
     }
 
     public function testPublicWorkoutCatalogIsReadOnly(): void


### PR DESCRIPTION
## Summary
- add API Platform filters for athlete search, workout catalog search, and workout result history
- allow result filtering by athlete/event/competition/division/source/rank and useful ordering
- cover athlete display-name search and athlete-result filtering with integration tests

## Checks
- docker compose exec php php bin/phpunit --colors=always
- docker compose exec php composer cs:check
- docker compose exec php php bin/console doctrine:schema:validate --env=test
- docker compose exec php composer psalm

Closes #90