### PR TITLE
Run Messenger worker in production

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -18,6 +18,8 @@ fallback.
   - `PYTHON_WORKER_BASE_URL`
 - PHP, Composer, PostgreSQL access, Nginx and PHP-FPM are already installed.
 - The deploy user can reload PHP-FPM with `sudo systemctl reload php8.4-fpm`.
+- The deploy user can restart the Messenger worker with
+  `sudo systemctl restart monwod-symfony-messenger` once the service is installed.
 
 ## Automatic Deploy
 
@@ -50,7 +52,9 @@ cd /var/www/crossfit
 ```
 
 The script updates `master`, installs production Composer dependencies, runs
-Doctrine migrations, clears and warms the Symfony cache, then reloads PHP-FPM.
+Doctrine migrations, clears and warms the Symfony cache, asks old Messenger
+workers to stop, reloads PHP-FPM, then restarts the Messenger worker when the
+systemd service exists.
 
 ## Manual Deploy
 
@@ -77,7 +81,48 @@ BRANCH=master \
 PHP_BIN=php \
 COMPOSER_BIN=composer \
 PHP_FPM_SERVICE=php8.4-fpm \
+MESSENGER_SERVICE=monwod-symfony-messenger \
 ./scripts/deploy_prod.sh
+```
+
+## Messenger Worker
+
+Symfony queues emails through Messenger. Production must therefore run a worker
+continuously, otherwise account validation and password reset emails remain in
+`messenger_messages`.
+
+Install or refresh the worker service on the server:
+
+```bash
+cd /var/www/crossfit
+sudo ./scripts/install_messenger_worker_service.sh
+```
+
+Useful overrides:
+
+```bash
+sudo PROJECT_DIR=/var/www/crossfit \
+PHP_BIN=/usr/bin/php \
+SERVICE_USER=ubuntu \
+SERVICE_GROUP=www-data \
+./scripts/install_messenger_worker_service.sh
+```
+
+Operate the worker:
+
+```bash
+sudo systemctl status monwod-symfony-messenger
+sudo systemctl restart monwod-symfony-messenger
+sudo journalctl -u monwod-symfony-messenger -f
+```
+
+Debug the queue:
+
+```bash
+php bin/console dbal:run-sql --force-fetch "SELECT COUNT(*) FROM messenger_messages;"
+php bin/console messenger:failed:show --env=prod
+php bin/console messenger:failed:retry --env=prod
+php bin/console messenger:failed:remove --all --env=prod
 ```
 
 ## Smoke Test

--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -7,6 +7,7 @@ BRANCH="${BRANCH:-master}"
 PHP_BIN="${PHP_BIN:-php}"
 COMPOSER_BIN="${COMPOSER_BIN:-composer}"
 PHP_FPM_SERVICE="${PHP_FPM_SERVICE:-php8.4-fpm}"
+MESSENGER_SERVICE="${MESSENGER_SERVICE:-monwod-symfony-messenger}"
 RUN_MIGRATIONS=1
 
 usage() {
@@ -17,6 +18,7 @@ usage() {
     printf '  PHP_BIN           Default: php\n'
     printf '  COMPOSER_BIN      Default: composer\n'
     printf '  PHP_FPM_SERVICE   Default: php8.4-fpm\n'
+    printf '  MESSENGER_SERVICE Default: monwod-symfony-messenger\n'
 }
 
 log() {
@@ -68,7 +70,17 @@ log "Clearing production cache"
 log "Warming production cache"
 "$PHP_BIN" bin/console cache:warmup --env=prod
 
+log "Stopping Messenger workers so systemd restarts them with fresh code"
+"$PHP_BIN" bin/console messenger:stop-workers --env=prod || true
+
 log "Reloading ${PHP_FPM_SERVICE}"
 sudo systemctl reload "$PHP_FPM_SERVICE"
+
+if systemctl cat "$MESSENGER_SERVICE" >/dev/null 2>&1; then
+    log "Restarting ${MESSENGER_SERVICE}"
+    sudo systemctl restart "$MESSENGER_SERVICE"
+else
+    log "Messenger service ${MESSENGER_SERVICE} is not installed; skipping restart"
+fi
 
 log "Deployment completed"

--- a/scripts/install_messenger_worker_service.sh
+++ b/scripts/install_messenger_worker_service.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-/var/www/crossfit}"
+PHP_BIN="${PHP_BIN:-/usr/bin/php}"
+SERVICE_NAME="${SERVICE_NAME:-monwod-symfony-messenger}"
+SERVICE_USER="${SERVICE_USER:-ubuntu}"
+SERVICE_GROUP="${SERVICE_GROUP:-www-data}"
+TIME_LIMIT="${TIME_LIMIT:-3600}"
+MEMORY_LIMIT="${MEMORY_LIMIT:-256M}"
+
+usage() {
+    printf 'Usage: sudo %s\n' "$0"
+    printf '\nEnvironment overrides:\n'
+    printf '  PROJECT_DIR    Default: /var/www/crossfit\n'
+    printf '  PHP_BIN        Default: /usr/bin/php\n'
+    printf '  SERVICE_NAME   Default: monwod-symfony-messenger\n'
+    printf '  SERVICE_USER   Default: ubuntu\n'
+    printf '  SERVICE_GROUP  Default: www-data\n'
+    printf '  TIME_LIMIT     Default: 3600\n'
+    printf '  MEMORY_LIMIT   Default: 256M\n'
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    printf 'This script must be run with sudo/root because it writes a systemd unit.\n' >&2
+    exit 1
+fi
+
+SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+
+cat > "$SERVICE_FILE" <<UNIT
+[Unit]
+Description=MonWOD Symfony Messenger worker
+After=network.target postgresql.service
+
+[Service]
+Type=simple
+User=${SERVICE_USER}
+Group=${SERVICE_GROUP}
+WorkingDirectory=${PROJECT_DIR}
+Environment=APP_ENV=prod
+Environment=APP_DEBUG=0
+ExecStart=${PHP_BIN} -d memory_limit=${MEMORY_LIMIT} bin/console messenger:consume async --env=prod --time-limit=${TIME_LIMIT} --memory-limit=${MEMORY_LIMIT}
+Restart=always
+RestartSec=10
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable "$SERVICE_NAME"
+systemctl restart "$SERVICE_NAME"
+systemctl status "$SERVICE_NAME" --no-pager


### PR DESCRIPTION
## Summary
- add a systemd installer script for the Symfony Messenger worker
- document Messenger operations and failed-message debugging
- update deploy script to stop old workers and restart the worker service when installed

## Checks
- bash -n scripts/deploy_prod.sh
- bash -n scripts/install_messenger_worker_service.sh

Closes #93