### PR TITLE
Add admin metrics API

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -30,6 +30,7 @@ security:
         - { path: ^/api/auth/(register|verify-email|login|forgot-password|reset-password)$, roles: PUBLIC_ACCESS }
         - { path: ^/api/auth/me$, roles: ROLE_USER }
         - { path: ^/api/me, roles: ROLE_USER }
+        - { path: ^/api/admin, roles: ROLE_ADMIN }
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }
 

--- a/src/Command/PromoteAdminUserCommand.php
+++ b/src/Command/PromoteAdminUserCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Security\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:user:promote-admin',
+    description: 'Grant ROLE_ADMIN to an existing user.',
+)]
+class PromoteAdminUserCommand extends Command
+{
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('email', InputArgument::REQUIRED, 'Email of the user to promote.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $email = strtolower(trim((string) $input->getArgument('email')));
+
+        if ($email === '') {
+            $io->error('Email is required.');
+
+            return Command::FAILURE;
+        }
+
+        $user = $this->findUserByEmail($email);
+        if ($user === null) {
+            $io->error(sprintf('User "%s" was not found.', $email));
+
+            return Command::FAILURE;
+        }
+
+        $roles = array_values(array_diff($user->getRoles(), ['ROLE_USER']));
+        if (!in_array('ROLE_ADMIN', $roles, true)) {
+            $roles[] = 'ROLE_ADMIN';
+            $user->setRoles($roles);
+            $this->entityManager->flush();
+        }
+
+        $io->success(sprintf('User "%s" is now admin.', $email));
+
+        return Command::SUCCESS;
+    }
+
+    private function findUserByEmail(string $email): ?User
+    {
+        /** @var User|null $user */
+        $user = $this->entityManager
+            ->createQueryBuilder()
+            ->select('user')
+            ->from(User::class, 'user')
+            ->where('LOWER(user.email) = :email')
+            ->setParameter('email', $email)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $user;
+    }
+}

--- a/src/Services/Admin/AdminDashboardMetricsProvider.php
+++ b/src/Services/Admin/AdminDashboardMetricsProvider.php
@@ -3,6 +3,10 @@
 namespace App\Services\Admin;
 
 use App\Entity\Competition\Athlete;
+use App\Entity\Competition\Competition;
+use App\Entity\Competition\CompetitionDivision;
+use App\Entity\Competition\CompetitionEvent;
+use App\Entity\Competition\WorkoutResult;
 use App\Entity\Product\Box;
 use App\Entity\Product\BoxMembership;
 use App\Entity\Product\PerformanceAnalysisRequest;
@@ -21,9 +25,14 @@ class AdminDashboardMetricsProvider
 
     /**
      * @return array{
-     *     workouts: array{total: int, by_source: array<string, int>},
-     *     athletes: array{total: int, by_source: array<string, int>},
-     *     users: array{total: int},
+     *     generated_at: string,
+     *     workouts: array{total: int, by_source: array<string, int>, by_type: array<string, int>, by_origin: array<string, int>, latest_created_at: ?string},
+     *     athletes: array{total: int, by_source: array<string, int>, latest_updated_at: ?string},
+     *     competitions: array{total: int, by_source: array<string, int>, latest_updated_at: ?string},
+     *     competition_events: array{total: int, by_source: array<string, int>, latest_updated_at: ?string},
+     *     competition_divisions: array{total: int, by_source: array<string, int>, latest_updated_at: ?string},
+     *     workout_results: array{total: int, by_source: array<string, int>, latest_updated_at: ?string},
+     *     users: array{total: int, verified: int, admins: int, latest_created_at: ?string},
      *     linked_athlete_profiles: array{total: int},
      *     performance_profiles: array{total: int},
      *     analysis_requests: array{total: int, by_status: array<string, int>},
@@ -35,16 +44,44 @@ class AdminDashboardMetricsProvider
     public function getMetrics(): array
     {
         return [
+            'generated_at' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
             'workouts' => [
                 'total' => $this->count(Workout::class),
                 'by_source' => $this->countByNullableField(Workout::class, 'sourceName', 'manual'),
+                'by_type' => $this->countByJoinedField(Workout::class, 'workoutType', 'name', 'unknown'),
+                'by_origin' => $this->countByJoinedPath(Workout::class, ['workoutOrigin', 'name'], 'name', 'unknown'),
+                'latest_created_at' => $this->latestDate(Workout::class, 'createdAt'),
             ],
             'athletes' => [
                 'total' => $this->count(Athlete::class),
                 'by_source' => $this->countByField(Athlete::class, 'sourceName'),
+                'latest_updated_at' => $this->latestDate(Athlete::class, 'updatedAt'),
+            ],
+            'competitions' => [
+                'total' => $this->count(Competition::class),
+                'by_source' => $this->countByField(Competition::class, 'sourceName'),
+                'latest_updated_at' => $this->latestDate(Competition::class, 'updatedAt'),
+            ],
+            'competition_events' => [
+                'total' => $this->count(CompetitionEvent::class),
+                'by_source' => $this->countByField(CompetitionEvent::class, 'sourceName'),
+                'latest_updated_at' => $this->latestDate(CompetitionEvent::class, 'updatedAt'),
+            ],
+            'competition_divisions' => [
+                'total' => $this->count(CompetitionDivision::class),
+                'by_source' => $this->countByField(CompetitionDivision::class, 'sourceName'),
+                'latest_updated_at' => $this->latestDate(CompetitionDivision::class, 'updatedAt'),
+            ],
+            'workout_results' => [
+                'total' => $this->count(WorkoutResult::class),
+                'by_source' => $this->countByField(WorkoutResult::class, 'sourceName'),
+                'latest_updated_at' => $this->latestDate(WorkoutResult::class, 'updatedAt'),
             ],
             'users' => [
                 'total' => $this->count(User::class),
+                'verified' => $this->countWhereNotNull(User::class, 'emailVerifiedAt'),
+                'admins' => $this->countUsersWithRole('ROLE_ADMIN'),
+                'latest_created_at' => $this->latestDate(User::class, 'createdAt'),
             ],
             'linked_athlete_profiles' => [
                 'total' => $this->count(UserAthleteProfile::class),
@@ -120,6 +157,109 @@ class AdminDashboardMetricsProvider
             ->getArrayResult();
 
         return $this->normalizeGroupedRows($rows);
+    }
+
+    /**
+     * @param class-string $entityClass
+     *
+     * @return array<string, int>
+     */
+    private function countByJoinedField(string $entityClass, string $association, string $field, string $fallback): array
+    {
+        $rows = $this->entityManager
+            ->createQueryBuilder()
+            ->select(sprintf('COALESCE(joined.%s, :fallback) AS metric_key', $field), 'COUNT(entity.id) AS metric_count')
+            ->from($entityClass, 'entity')
+            ->leftJoin(sprintf('entity.%s', $association), 'joined')
+            ->groupBy('metric_key')
+            ->orderBy('metric_key', 'ASC')
+            ->setParameter('fallback', $fallback)
+            ->getQuery()
+            ->getArrayResult();
+
+        return $this->normalizeGroupedRows($rows);
+    }
+
+    /**
+     * @param class-string $entityClass
+     * @param list<string> $associations
+     *
+     * @return array<string, int>
+     */
+    private function countByJoinedPath(string $entityClass, array $associations, string $field, string $fallback): array
+    {
+        $queryBuilder = $this->entityManager
+            ->createQueryBuilder()
+            ->from($entityClass, 'entity');
+
+        $previousAlias = 'entity';
+        foreach ($associations as $index => $association) {
+            $alias = sprintf('joined_%d', $index);
+            $queryBuilder->leftJoin(sprintf('%s.%s', $previousAlias, $association), $alias);
+            $previousAlias = $alias;
+        }
+
+        $rows = $queryBuilder
+            ->select(sprintf('COALESCE(%s.%s, :fallback) AS metric_key', $previousAlias, $field), 'COUNT(entity.id) AS metric_count')
+            ->groupBy('metric_key')
+            ->orderBy('metric_key', 'ASC')
+            ->setParameter('fallback', $fallback)
+            ->getQuery()
+            ->getArrayResult();
+
+        return $this->normalizeGroupedRows($rows);
+    }
+
+    /**
+     * @param class-string $entityClass
+     */
+    private function countWhereNotNull(string $entityClass, string $field): int
+    {
+        return (int) $this->entityManager
+            ->createQueryBuilder()
+            ->select('COUNT(entity.id)')
+            ->from($entityClass, 'entity')
+            ->where(sprintf('entity.%s IS NOT NULL', $field))
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    private function countUsersWithRole(string $role): int
+    {
+        $users = $this->entityManager
+            ->createQueryBuilder()
+            ->select('entity.roles')
+            ->from(User::class, 'entity')
+            ->getQuery()
+            ->getArrayResult();
+
+        return count(array_filter(
+            $users,
+            static fn (array $row): bool => in_array($role, $row['roles'] ?? [], true)
+        ));
+    }
+
+    /**
+     * @param class-string $entityClass
+     */
+    private function latestDate(string $entityClass, string $field): ?string
+    {
+        $latest = $this->entityManager
+            ->createQueryBuilder()
+            ->select(sprintf('MAX(entity.%s)', $field))
+            ->from($entityClass, 'entity')
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        if ($latest instanceof \DateTimeInterface) {
+            return $latest->format(\DateTimeInterface::ATOM);
+        }
+
+        if (is_string($latest) && $latest !== '') {
+            return (new \DateTimeImmutable($latest))->format(\DateTimeInterface::ATOM);
+        }
+
+        return null;
     }
 
     /**

--- a/tests/AdminDashboardMetricsTest.php
+++ b/tests/AdminDashboardMetricsTest.php
@@ -4,6 +4,12 @@ namespace App\Tests;
 
 use App\DataFixtures\WorkoutData;
 use App\Entity\Competition\Athlete;
+use App\Entity\Competition\Competition;
+use App\Entity\Competition\CompetitionDivision;
+use App\Entity\Competition\CompetitionEvent;
+use App\Entity\Competition\Enum\ScoreTypeEnum;
+use App\Entity\Competition\Score;
+use App\Entity\Competition\WorkoutResult;
 use App\Entity\Product\Box;
 use App\Entity\Product\BoxMembership;
 use App\Entity\Product\Enum\ProgrammingGenerationTypeEnum;
@@ -30,6 +36,13 @@ class AdminDashboardMetricsTest extends AbstractIntegrationTest
         $fran->setSourceName('crossfit_games');
 
         $athlete = new Athlete('Tia-Clair Toomey', 'crossfit_games', 'tia-clair-toomey');
+        $competition = (new Competition('CrossFit Games', 'crossfit_games', 'games-2026'))->setSeason(2026);
+        $event = new CompetitionEvent($competition, 'Final', 'crossfit_games', 'games-2026-final');
+        $division = new CompetitionDivision($competition, 'Women', 'crossfit_games', 'games-2026-women');
+        $score = (new Score(ScoreTypeEnum::REPS, '100'))->setNumericValue(100);
+        $result = (new WorkoutResult($athlete, $event, $score, 'crossfit_games', 'games-2026-final-tct'))
+            ->setCompetitionDivision($division)
+            ->setRank(1);
         $athleteProfile = new UserAthleteProfile($member, $athlete);
         $performanceProfile = new UserPerformanceProfile($member);
         $analysisRequest = new PerformanceAnalysisRequest($member, $performanceProfile, $athleteProfile);
@@ -45,6 +58,10 @@ class AdminDashboardMetricsTest extends AbstractIntegrationTest
         $entityManager->persist($admin);
         $entityManager->persist($member);
         $entityManager->persist($athlete);
+        $entityManager->persist($competition);
+        $entityManager->persist($event);
+        $entityManager->persist($division);
+        $entityManager->persist($result);
         $entityManager->persist($athleteProfile);
         $entityManager->persist($performanceProfile);
         $entityManager->persist($analysisRequest);
@@ -63,11 +80,19 @@ class AdminDashboardMetricsTest extends AbstractIntegrationTest
         self::assertGreaterThanOrEqual(1, $payload['workouts']['total']);
         self::assertSame(1, $payload['workouts']['by_source']['crossfit_games']);
         self::assertArrayHasKey('manual', $payload['workouts']['by_source']);
+        self::assertNotNull($payload['workouts']['latest_created_at']);
 
         self::assertGreaterThanOrEqual(1, $payload['athletes']['total']);
         self::assertSame(1, $payload['athletes']['by_source']['crossfit_games']);
 
+        self::assertSame(1, $payload['competitions']['total']);
+        self::assertSame(1, $payload['competition_events']['total']);
+        self::assertSame(1, $payload['competition_divisions']['total']);
+        self::assertSame(1, $payload['workout_results']['total']);
+        self::assertSame(1, $payload['workout_results']['by_source']['crossfit_games']);
+
         self::assertGreaterThanOrEqual(2, $payload['users']['total']);
+        self::assertSame(1, $payload['users']['admins']);
         self::assertSame(1, $payload['linked_athlete_profiles']['total']);
         self::assertSame(1, $payload['performance_profiles']['total']);
         self::assertSame(1, $payload['analysis_requests']['by_status']['queued']);
@@ -89,5 +114,12 @@ class AdminDashboardMetricsTest extends AbstractIntegrationTest
         $this->browser()->request('GET', '/api/admin/metrics');
 
         self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testAnonymousUsersCannotReadAdminMetrics(): void
+    {
+        $this->browser()->request('GET', '/api/admin/metrics');
+
+        self::assertContains($this->browser()->getResponse()->getStatusCode(), [401, 403]);
     }
 }

--- a/tests/PromoteAdminUserCommandTest.php
+++ b/tests/PromoteAdminUserCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Tests;
+
+use App\Command\PromoteAdminUserCommand;
+use App\Entity\Security\User;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class PromoteAdminUserCommandTest extends AbstractIntegrationTest
+{
+    public function testExistingUserCanBePromotedToAdmin(): void
+    {
+        $user = new User('admin@example.com');
+        $user->setPassword('test-password');
+        $this->getEntityManager()->persist($user);
+        $this->getEntityManager()->flush();
+
+        $tester = new CommandTester(new PromoteAdminUserCommand($this->getEntityManager()));
+        $statusCode = $tester->execute(['email' => 'ADMIN@example.com']);
+
+        self::assertSame(Command::SUCCESS, $statusCode);
+
+        $this->getEntityManager()->refresh($user);
+        self::assertContains('ROLE_ADMIN', $user->getRoles());
+    }
+
+    public function testUnknownUserCannotBePromoted(): void
+    {
+        $tester = new CommandTester(new PromoteAdminUserCommand($this->getEntityManager()));
+        $statusCode = $tester->execute(['email' => 'missing@example.com']);
+
+        self::assertSame(Command::FAILURE, $statusCode);
+    }
+}


### PR DESCRIPTION
## Summary
- protect /api/admin behind ROLE_ADMIN
- add app:user:promote-admin to grant admin access to an existing user
- expand admin metrics with crawler/product/auth volumes and freshness timestamps

## Checks
- composer cs:check
- composer psalm
- php bin/console lint:yaml config --env=test
- php -l src/Command/PromoteAdminUserCommand.php
- php -l src/Services/Admin/AdminDashboardMetricsProvider.php

Local DB-backed PHPUnit could not run here because Docker is not available locally; CI should cover it.

Closes #92