### PR TITLE
Add email verification resend endpoint

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -27,7 +27,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
-        - { path: ^/api/auth/(register|verify-email|login|forgot-password|reset-password)$, roles: PUBLIC_ACCESS }
+        - { path: ^/api/auth/(register|verify-email|resend-verification|login|forgot-password|reset-password)$, roles: PUBLIC_ACCESS }
         - { path: ^/api/auth/me$, roles: ROLE_USER }
         - { path: ^/api/me, roles: ROLE_USER }
         - { path: ^/api/admin, roles: ROLE_ADMIN }

--- a/src/Controller/Security/AuthController.php
+++ b/src/Controller/Security/AuthController.php
@@ -77,6 +77,29 @@ class AuthController extends AbstractController
         return $this->json(['status' => 'email_verified']);
     }
 
+    #[Route('/resend-verification', name: 'api_auth_resend_verification', methods: ['POST'])]
+    public function resendVerification(Request $request): JsonResponse
+    {
+        $payload = $this->jsonPayload($request);
+        $email = $this->email($payload['email'] ?? null);
+
+        /** @var User|null $user */
+        $user = $email !== null ? $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]) : null;
+        if ($user !== null && !$user->isEmailVerified()) {
+            $plainToken = $this->tokenFactory->createPlainToken();
+            $this->entityManager->persist(new UserToken(
+                $user,
+                $plainToken,
+                UserToken::PURPOSE_EMAIL_VERIFICATION,
+                new \DateTimeImmutable('+48 hours'),
+            ));
+            $this->entityManager->flush();
+            $this->authEmailSender->sendEmailVerification($user, $plainToken);
+        }
+
+        return $this->json(['status' => 'verification_email_requested']);
+    }
+
     #[Route('/login', name: 'api_auth_login', methods: ['POST'])]
     public function login(Request $request): JsonResponse
     {
@@ -90,7 +113,10 @@ class AuthController extends AbstractController
             return $this->json(['error' => 'Invalid credentials.'], Response::HTTP_UNAUTHORIZED);
         }
         if (!$user->isEmailVerified()) {
-            return $this->json(['error' => 'Email must be verified before login.'], Response::HTTP_FORBIDDEN);
+            return $this->json([
+                'error' => 'Email must be verified before login.',
+                'code' => 'email_not_verified',
+            ], Response::HTTP_FORBIDDEN);
         }
 
         $plainToken = $this->tokenFactory->createPlainToken();

--- a/tests/AuthWorkflowTest.php
+++ b/tests/AuthWorkflowTest.php
@@ -29,6 +29,14 @@ class AuthWorkflowTest extends AbstractIntegrationTest
         ]);
 
         self::assertResponseStatusCodeSame(403);
+        self::assertSame('email_not_verified', $this->jsonResponse()['code']);
+
+        $this->jsonRequest('POST', '/api/auth/resend-verification', [
+            'email' => 'athlete@example.com',
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertSame(['status' => 'verification_email_requested'], $this->jsonResponse());
 
         /** @var UserToken|null $verificationToken */
         $verificationToken = $this->getRepository(UserToken::class)->findOneBy([
@@ -37,6 +45,11 @@ class AuthWorkflowTest extends AbstractIntegrationTest
             'consumedAt' => null,
         ]);
         self::assertNotNull($verificationToken);
+        self::assertCount(2, $this->getRepository(UserToken::class)->findBy([
+            'user' => $user,
+            'purpose' => UserToken::PURPOSE_EMAIL_VERIFICATION,
+            'consumedAt' => null,
+        ]));
 
         $this->jsonRequest('POST', '/api/auth/verify-email', [
             'token' => 'invalid-token',


### PR DESCRIPTION
## Summary
- add POST /api/auth/resend-verification
- return a stable email_not_verified code on blocked login
- keep resend response generic so user existence is not leaked
- cover the resend flow in AuthWorkflowTest

## Checks
- composer cs:check
- composer psalm
- php bin/console lint:yaml config --env=test

PHPUnit was attempted locally, but the local DB host db is unavailable outside Docker; CI should run the DB-backed test suite.