### PR TITLE
Allow deleting performance metrics

### DIFF
--- a/src/Controller/Profile/MeController.php
+++ b/src/Controller/Profile/MeController.php
@@ -132,6 +132,29 @@ class MeController extends AbstractController
         return $this->json(['performanceProfile' => $this->serializePerformanceProfile($profile)]);
     }
 
+    #[Route('/performance-profile/metrics/{key}', name: 'api_me_delete_performance_metric', methods: ['DELETE'])]
+    public function deletePerformanceMetric(string $key): JsonResponse
+    {
+        $metricKey = PerformanceMetricKeyEnum::tryFrom($key);
+        if ($metricKey === null) {
+            return $this->json(['error' => sprintf('Unknown metric key "%s".', $key)], Response::HTTP_BAD_REQUEST);
+        }
+
+        $profile = $this->getLatestPerformanceProfile($this->currentUser());
+        if ($profile === null) {
+            return $this->json(['performanceProfile' => null]);
+        }
+
+        $metric = $profile->getMetric($metricKey);
+        if ($metric !== null) {
+            $profile->removeMetric($metric);
+            $this->entityManager->remove($metric);
+            $this->entityManager->flush();
+        }
+
+        return $this->json(['performanceProfile' => $this->serializePerformanceProfile($profile)]);
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/src/Entity/Product/UserPerformanceProfile.php
+++ b/src/Entity/Product/UserPerformanceProfile.php
@@ -95,6 +95,15 @@ class UserPerformanceProfile
         return $this;
     }
 
+    public function removeMetric(UserPerformanceMetric $metric): self
+    {
+        if ($this->metrics->removeElement($metric)) {
+            $this->touch();
+        }
+
+        return $this;
+    }
+
     public function getMetric(PerformanceMetricKeyEnum $metricKey): ?UserPerformanceMetric
     {
         foreach ($this->metrics as $metric) {

--- a/tests/PrivateUserProfileApiTest.php
+++ b/tests/PrivateUserProfileApiTest.php
@@ -109,6 +109,18 @@ class PrivateUserProfileApiTest extends AbstractIntegrationTest
         $storedProfile = $storedUser->getPerformanceProfiles()->first();
         self::assertSame(150.0, $storedProfile->getMetric(PerformanceMetricKeyEnum::BACK_SQUAT_1RM)?->getNumericValue());
         self::assertTrue($storedProfile->getMetric(PerformanceMetricKeyEnum::STRICT_PULL_UP)?->getBooleanValue());
+
+        $this->jsonRequest(
+            'DELETE',
+            '/api/me/performance-profile/metrics/'.PerformanceMetricKeyEnum::STRICT_PULL_UP->value,
+            [],
+            $token
+        );
+
+        self::assertResponseIsSuccessful();
+        $profilePayload = $this->jsonResponse()['performanceProfile'];
+        self::assertCount(1, $profilePayload['metrics']);
+        self::assertSame(PerformanceMetricKeyEnum::BACK_SQUAT_1RM->value, $profilePayload['metrics'][0]['key']);
     }
 
     public function testMetricPayloadIsValidatedAgainstMetricType(): void


### PR DESCRIPTION
## Summary
- add DELETE /api/me/performance-profile/metrics/{key}
- remove a metric from the latest user performance profile
- keep the response aligned with the existing performanceProfile payload
- cover deletion in the private profile API test

## Checks
- composer cs:check
- composer psalm
- php -l src/Controller/Profile/MeController.php
- php -l src/Entity/Product/UserPerformanceProfile.php

Local DB-backed PHPUnit is still blocked outside Docker by the local db hostname; CI should run it.