### PR TITLE
Add member request APIs

### DIFF
--- a/src/Controller/Profile/MeController.php
+++ b/src/Controller/Profile/MeController.php
@@ -6,6 +6,9 @@ use App\Entity\Competition\Athlete;
 use App\Entity\Product\Enum\PerformanceMetricCategoryEnum;
 use App\Entity\Product\Enum\PerformanceMetricKeyEnum;
 use App\Entity\Product\Enum\PerformanceMetricValueTypeEnum;
+use App\Entity\Product\Enum\ProgrammingGenerationTypeEnum;
+use App\Entity\Product\PerformanceAnalysisRequest;
+use App\Entity\Product\ProgrammingGenerationRequest;
 use App\Entity\Product\UserAthleteProfile;
 use App\Entity\Product\UserPerformanceMetric;
 use App\Entity\Product\UserPerformanceProfile;
@@ -132,6 +135,104 @@ class MeController extends AbstractController
         return $this->json(['performanceProfile' => $this->serializePerformanceProfile($profile)]);
     }
 
+    #[Route('/requests', name: 'api_me_requests', methods: ['GET'])]
+    public function requests(): JsonResponse
+    {
+        $user = $this->currentUser();
+
+        return $this->json([
+            'analysisRequests' => array_map(
+                fn (PerformanceAnalysisRequest $request): array => $this->serializeAnalysisRequest($request),
+                $this->entityManager->getRepository(PerformanceAnalysisRequest::class)->findBy(
+                    ['user' => $user],
+                    ['createdAt' => 'DESC'],
+                    20
+                )
+            ),
+            'programmingRequests' => array_map(
+                fn (ProgrammingGenerationRequest $request): array => $this->serializeProgrammingRequest($request),
+                $this->entityManager->getRepository(ProgrammingGenerationRequest::class)->findBy(
+                    ['user' => $user],
+                    ['createdAt' => 'DESC'],
+                    20
+                )
+            ),
+        ]);
+    }
+
+    #[Route('/performance-analysis-requests', name: 'api_me_create_performance_analysis_request', methods: ['POST'])]
+    public function createPerformanceAnalysisRequest(Request $request): JsonResponse
+    {
+        $user = $this->currentUser();
+        $profile = $this->getLatestPerformanceProfile($user);
+        if ($profile === null) {
+            return $this->json(['error' => 'Performance profile is required.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $payload = $this->jsonPayload($request);
+        $athleteProfile = null;
+        $athleteProfileId = $payload['athleteProfileId'] ?? null;
+        if (is_string($athleteProfileId) && $athleteProfileId !== '') {
+            /** @var UserAthleteProfile|null $athleteProfile */
+            $athleteProfile = $this->entityManager->getRepository(UserAthleteProfile::class)->find($athleteProfileId);
+            if ($athleteProfile === null || $athleteProfile->getUser() !== $user) {
+                return $this->json(['error' => 'Athlete profile not found.'], Response::HTTP_NOT_FOUND);
+            }
+        }
+
+        $parameters = $this->arrayPayload($payload['parameters'] ?? []);
+        $analysisRequest = (new PerformanceAnalysisRequest(
+            $user,
+            $profile,
+            $athleteProfile,
+            $parameters,
+            $this->buildAnalysisSnapshot($profile, $athleteProfile)
+        ))->markQueued();
+
+        $this->entityManager->persist($analysisRequest);
+        $this->entityManager->flush();
+
+        return $this->json(
+            ['analysisRequest' => $this->serializeAnalysisRequest($analysisRequest)],
+            Response::HTTP_CREATED
+        );
+    }
+
+    #[Route('/programming-generation-requests', name: 'api_me_create_programming_generation_request', methods: ['POST'])]
+    public function createProgrammingGenerationRequest(Request $request): JsonResponse
+    {
+        $user = $this->currentUser();
+        $payload = $this->jsonPayload($request);
+        $typeValue = $payload['type'] ?? null;
+        if (!is_string($typeValue)) {
+            return $this->json(['error' => 'type is required.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $type = ProgrammingGenerationTypeEnum::tryFrom($typeValue);
+        if ($type === null) {
+            return $this->json(['error' => 'Invalid programming generation type.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $profile = $this->getLatestPerformanceProfile($user);
+        $constraints = $this->arrayPayload($payload['constraints'] ?? []);
+        $programmingRequest = (new ProgrammingGenerationRequest(
+            $user,
+            $type,
+            $constraints,
+            $this->buildProgrammingSnapshot($profile)
+        ))
+            ->setPerformanceProfile($profile)
+            ->markQueued();
+
+        $this->entityManager->persist($programmingRequest);
+        $this->entityManager->flush();
+
+        return $this->json(
+            ['programmingRequest' => $this->serializeProgrammingRequest($programmingRequest)],
+            Response::HTTP_CREATED
+        );
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -220,6 +321,51 @@ class MeController extends AbstractController
             'booleanValue' => $metric->getBooleanValue(),
             'unit' => $metric->getUnit(),
             'notes' => $metric->getNotes(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeAnalysisRequest(PerformanceAnalysisRequest $request): array
+    {
+        return [
+            'id' => (string) $request->getId(),
+            'status' => $request->getStatus()->value,
+            'eligibleAtCreation' => $request->wasEligibleAtCreation(),
+            'parameters' => $request->getParameters(),
+            'inputSnapshot' => $request->getInputSnapshot(),
+            'result' => $request->getResult(),
+            'errorMessage' => $request->getErrorMessage(),
+            'createdAt' => $this->date($request->getCreatedAt()),
+            'updatedAt' => $this->date($request->getUpdatedAt()),
+            'queuedAt' => $this->date($request->getQueuedAt()),
+            'startedAt' => $this->date($request->getStartedAt()),
+            'completedAt' => $this->date($request->getCompletedAt()),
+            'athleteProfile' => $request->getAthleteProfile() !== null
+                ? $this->serializeAthleteProfile($request->getAthleteProfile())
+                : null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeProgrammingRequest(ProgrammingGenerationRequest $request): array
+    {
+        return [
+            'id' => (string) $request->getId(),
+            'type' => $request->getType()->value,
+            'status' => $request->getStatus()->value,
+            'constraints' => $request->getConstraints(),
+            'inputSnapshot' => $request->getInputSnapshot(),
+            'generatedProgramming' => $request->getGeneratedProgramming(),
+            'errorMessage' => $request->getErrorMessage(),
+            'createdAt' => $this->date($request->getCreatedAt()),
+            'updatedAt' => $this->date($request->getUpdatedAt()),
+            'queuedAt' => $this->date($request->getQueuedAt()),
+            'startedAt' => $this->date($request->getStartedAt()),
+            'completedAt' => $this->date($request->getCompletedAt()),
         ];
     }
 
@@ -320,6 +466,49 @@ class MeController extends AbstractController
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    private function buildAnalysisSnapshot(UserPerformanceProfile $profile, ?UserAthleteProfile $athleteProfile): array
+    {
+        return [
+            'performance_metrics' => $this->performanceMetricSnapshot($profile),
+            'athlete_profile' => $athleteProfile !== null ? [
+                'id' => (string) $athleteProfile->getId(),
+                'athlete_id' => (string) $athleteProfile->getAthlete()->getId(),
+                'display_name' => $athleteProfile->getAthlete()->getDisplayName(),
+                'source_name' => $athleteProfile->getAthlete()->getSourceName(),
+                'external_id' => $athleteProfile->getAthlete()->getExternalId(),
+            ] : null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildProgrammingSnapshot(?UserPerformanceProfile $profile): array
+    {
+        return [
+            'performance_profile_id' => $profile?->getId() !== null ? (string) $profile->getId() : null,
+            'performance_metrics' => $profile !== null ? $this->performanceMetricSnapshot($profile) : [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function performanceMetricSnapshot(UserPerformanceProfile $profile): array
+    {
+        $metrics = [];
+        foreach ($profile->getMetrics() as $metric) {
+            $metrics[$metric->getMetricKey()->value] = $metric->getValueType() === PerformanceMetricValueTypeEnum::BOOLEAN
+                ? $metric->getBooleanValue()
+                : $metric->getNumericValue();
+        }
+
+        return $metrics;
+    }
+
+    /**
      * @return list<string>
      */
     private function missingRequiredMetrics(UserPerformanceProfile $profile): array
@@ -362,6 +551,18 @@ class MeController extends AbstractController
         }
 
         return is_array($payload) ? $payload : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function arrayPayload(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return $value;
     }
 
     private function currentUser(): User

--- a/tests/PrivateUserProfileApiTest.php
+++ b/tests/PrivateUserProfileApiTest.php
@@ -4,7 +4,9 @@ namespace App\Tests;
 
 use App\Entity\Competition\Athlete;
 use App\Entity\Product\Enum\PerformanceMetricKeyEnum;
+use App\Entity\Product\Enum\ProgrammingGenerationTypeEnum;
 use App\Entity\Product\UserAthleteProfile;
+use App\Entity\Product\UserPerformanceMetric;
 use App\Entity\Product\UserPerformanceProfile;
 use App\Entity\Security\User;
 use App\Entity\Security\UserToken;
@@ -129,6 +131,58 @@ class PrivateUserProfileApiTest extends AbstractIntegrationTest
             'Metric "strict_pull_up" expects a booleanValue.',
             $this->jsonResponse()['error']
         );
+    }
+
+    public function testUserCanCreateAnalysisAndProgrammingRequests(): void
+    {
+        [$token, $user] = $this->createAuthenticatedUser('requests@example.com', 'requests-token');
+        $athlete = new Athlete('Bruno Athlete', 'competition_corner', 'bruno-123');
+        $athleteProfile = (new UserAthleteProfile($user, $athlete))->setPrimaryProfile(true);
+        $performanceProfile = new UserPerformanceProfile($user);
+        (new UserPerformanceMetric($performanceProfile, PerformanceMetricKeyEnum::BACK_SQUAT_1RM))->setNumericValue(150);
+        (new UserPerformanceMetric($performanceProfile, PerformanceMetricKeyEnum::STRICT_PULL_UP))->setBooleanValue(true);
+
+        $this->getEntityManager()->persist($athlete);
+        $this->getEntityManager()->persist($athleteProfile);
+        $this->getEntityManager()->persist($performanceProfile);
+        $this->getEntityManager()->flush();
+
+        $this->jsonRequest('POST', '/api/me/performance-analysis-requests', [
+            'athleteProfileId' => (string) $athleteProfile->getId(),
+            'parameters' => [
+                'goal' => 'identify weaknesses',
+            ],
+        ], $token);
+
+        self::assertResponseStatusCodeSame(201);
+        $analysisPayload = $this->jsonResponse()['analysisRequest'];
+        self::assertSame('queued', $analysisPayload['status']);
+        self::assertSame('identify weaknesses', $analysisPayload['parameters']['goal']);
+        self::assertSame('Bruno Athlete', $analysisPayload['athleteProfile']['athlete']['displayName']);
+        self::assertSame(150.0, $analysisPayload['inputSnapshot']['performance_metrics'][PerformanceMetricKeyEnum::BACK_SQUAT_1RM->value]);
+
+        $this->jsonRequest('POST', '/api/me/programming-generation-requests', [
+            'type' => ProgrammingGenerationTypeEnum::INDIVIDUAL->value,
+            'constraints' => [
+                'durationWeeks' => 8,
+                'sessionsPerWeek' => 5,
+                'goal' => 'gymnastics endurance',
+            ],
+        ], $token);
+
+        self::assertResponseStatusCodeSame(201);
+        $programmingPayload = $this->jsonResponse()['programmingRequest'];
+        self::assertSame('queued', $programmingPayload['status']);
+        self::assertSame(ProgrammingGenerationTypeEnum::INDIVIDUAL->value, $programmingPayload['type']);
+        self::assertSame('gymnastics endurance', $programmingPayload['constraints']['goal']);
+        self::assertSame(true, $programmingPayload['inputSnapshot']['performance_metrics'][PerformanceMetricKeyEnum::STRICT_PULL_UP->value]);
+
+        $this->jsonRequest('GET', '/api/me/requests', [], $token);
+
+        self::assertResponseIsSuccessful();
+        $requestsPayload = $this->jsonResponse();
+        self::assertCount(1, $requestsPayload['analysisRequests']);
+        self::assertCount(1, $requestsPayload['programmingRequests']);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add member endpoints to list analysis/programming requests
- add member endpoint to create queued performance analysis requests
- add member endpoint to create queued programming generation requests
- serialize request status, timestamps, inputs, results, and errors for the front
- cover request creation/history in PrivateUserProfileApiTest

## Checks
- php -l src/Controller/Profile/MeController.php
- php -l tests/PrivateUserProfileApiTest.php
- composer cs:check
- composer psalm

## Not run
- php bin/phpunit tests/PrivateUserProfileApiTest.php: local test database host db is not resolvable outside Docker in this environment.