### PR TITLE
Expose workout competition context

### DIFF
--- a/src/Entity/Competition/CompetitionEvent.php
+++ b/src/Entity/Competition/CompetitionEvent.php
@@ -6,7 +6,10 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use App\Entity\Workout\Workout;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity]
@@ -25,7 +28,7 @@ class CompetitionEvent
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private Competition $competition;
 
-    #[ORM\ManyToOne(targetEntity: Workout::class)]
+    #[ORM\ManyToOne(targetEntity: Workout::class, inversedBy: 'competitionEvents')]
     #[ORM\JoinColumn(nullable: true)]
     private ?Workout $workout = null;
 
@@ -50,6 +53,9 @@ class CompetitionEvent
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $updatedAt;
 
+    #[ORM\OneToMany(mappedBy: 'event', targetEntity: WorkoutResult::class)]
+    private Collection $results;
+
     public function __construct(Competition $competition, string $name, string $sourceName, string $externalId)
     {
         $this->competition = $competition;
@@ -58,6 +64,7 @@ class CompetitionEvent
         $this->externalId = $externalId;
         $this->createdAt = new \DateTimeImmutable();
         $this->updatedAt = new \DateTimeImmutable();
+        $this->results = new ArrayCollection();
     }
 
     public function getId(): ?Uuid
@@ -140,6 +147,15 @@ class CompetitionEvent
     public function getUpdatedAt(): \DateTimeImmutable
     {
         return $this->updatedAt;
+    }
+
+    /**
+     * @return Collection<int, WorkoutResult>
+     */
+    #[Ignore]
+    public function getResults(): Collection
+    {
+        return $this->results;
     }
 
     private function touch(): void

--- a/src/Entity/Competition/WorkoutResult.php
+++ b/src/Entity/Competition/WorkoutResult.php
@@ -38,7 +38,7 @@ class WorkoutResult
     #[ORM\JoinColumn(nullable: false)]
     private Athlete $athlete;
 
-    #[ORM\ManyToOne(targetEntity: CompetitionEvent::class)]
+    #[ORM\ManyToOne(targetEntity: CompetitionEvent::class, inversedBy: 'results')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private CompetitionEvent $event;
 

--- a/src/Entity/Workout/Workout.php
+++ b/src/Entity/Workout/Workout.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use App\Entity\Competition\CompetitionEvent;
 use App\Entity\WorkoutGeneration\WorkoutGeneration;
 use App\Repository\Workout\WorkoutRepository;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -72,6 +73,9 @@ class Workout
     #[ORM\OneToOne(targetEntity: WorkoutGeneration::class, cascade: ['remove'])]
     private ?WorkoutGeneration $workoutGeneration = null;
 
+    #[ORM\OneToMany(mappedBy: 'workout', targetEntity: CompetitionEvent::class)]
+    private Collection $competitionEvents;
+
     public function __construct(
         ?string $name,
         string $flow,
@@ -84,6 +88,7 @@ class Workout
     ) {
         $this->implements = new ArrayCollection();
         $this->movements = new ArrayCollection();
+        $this->competitionEvents = new ArrayCollection();
 
         $this->name = $name;
         $this->flow = $flow;
@@ -233,6 +238,76 @@ class Workout
     public function getWorkoutGeneration(): ?WorkoutGeneration
     {
         return $this->workoutGeneration;
+    }
+
+    /**
+     * @return list<array{
+     *     competitionName: string,
+     *     competitionSeason: int|null,
+     *     eventName: string,
+     *     eventOrder: int|null,
+     *     sourceName: string,
+     *     divisions: list<string>
+     * }>
+     */
+    public function getCompetitionContexts(): array
+    {
+        $contexts = [];
+        $seen = [];
+
+        /** @var CompetitionEvent $event */
+        foreach ($this->competitionEvents as $event) {
+            $competition = $event->getCompetition();
+            $divisions = [];
+
+            foreach ($event->getResults() as $result) {
+                $division = $result->getCompetitionDivision()?->getName() ?? $result->getDivision();
+                if ($division !== null && $division !== '') {
+                    $divisions[$division] = true;
+                }
+            }
+
+            $divisionNames = array_keys($divisions);
+            sort($divisionNames, SORT_NATURAL | SORT_FLAG_CASE);
+
+            $context = [
+                'competitionName' => $competition->getName(),
+                'competitionSeason' => $competition->getSeason(),
+                'eventName' => $event->getName(),
+                'eventOrder' => $event->getEventOrder(),
+                'sourceName' => $event->getSourceName(),
+                'divisions' => $divisionNames,
+            ];
+            $key = implode('|', [
+                $context['competitionName'],
+                (string) $context['competitionSeason'],
+                $context['eventName'],
+                (string) $context['eventOrder'],
+                $context['sourceName'],
+                implode(',', $divisionNames),
+            ]);
+
+            if (!isset($seen[$key])) {
+                $contexts[] = $context;
+                $seen[$key] = true;
+            }
+        }
+
+        usort($contexts, static function (array $left, array $right): int {
+            return [
+                $right['competitionSeason'] ?? 0,
+                $left['competitionName'],
+                $left['eventOrder'] ?? PHP_INT_MAX,
+                $left['eventName'],
+            ] <=> [
+                $left['competitionSeason'] ?? 0,
+                $right['competitionName'],
+                $right['eventOrder'] ?? PHP_INT_MAX,
+                $right['eventName'],
+            ];
+        });
+
+        return $contexts;
     }
 
     public function setWorkoutGeneration(?WorkoutGeneration $workoutGeneration): static

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests;
 
+use App\DataFixtures\WorkoutData;
 use App\Entity\Competition\Athlete;
 use App\Entity\Competition\Competition;
 use App\Entity\Competition\CompetitionDivision;
@@ -9,6 +10,7 @@ use App\Entity\Competition\CompetitionEvent;
 use App\Entity\Competition\Enum\ScoreTypeEnum;
 use App\Entity\Competition\Score;
 use App\Entity\Competition\WorkoutResult;
+use App\Entity\Workout\Workout;
 
 class WorkoutApiWorkflowTest extends AbstractIntegrationTest
 {
@@ -24,6 +26,48 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
 
         self::assertContains('Fran', $names);
         self::assertLessThanOrEqual(50, count($workouts));
+    }
+
+    public function testFrontendCanReadWorkoutCompetitionContext(): void
+    {
+        $entityManager = $this->getEntityManager();
+        /** @var Workout $workout */
+        $workout = $this->getReference(WorkoutData::WORKOUT_OPEN_17_5, Workout::class);
+        $workoutId = (string) $workout->getId();
+        $athlete = new Athlete('Tia-Clair Toomey', 'crossfit_games', 'tia-context');
+        $competition = (new Competition('CrossFit Games Open', 'crossfit_games', 'open-2017'))
+            ->setSeason(2017);
+        $event = (new CompetitionEvent($competition, 'Open 17.5', 'crossfit_games', 'open-2017-17-5'))
+            ->setEventOrder(5)
+            ->setWorkout($workout);
+        $division = new CompetitionDivision($competition, 'Women', 'crossfit_games', 'open-2017-women');
+        $result = (new WorkoutResult($athlete, $event, new Score(ScoreTypeEnum::TIME, '10:21'), 'crossfit_games', 'open-2017-tia'))
+            ->setCompetitionDivision($division)
+            ->setDivision('Women')
+            ->setRank(1);
+
+        foreach ([$athlete, $competition, $event, $division, $result] as $entity) {
+            $entityManager->persist($entity);
+        }
+        $entityManager->flush();
+        $entityManager->clear();
+
+        $this->browser()->request('GET', sprintf('/api/workouts/%s', $workoutId));
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame([
+            [
+                'competitionName' => 'CrossFit Games Open',
+                'competitionSeason' => 2017,
+                'eventName' => 'Open 17.5',
+                'eventOrder' => 5,
+                'sourceName' => 'crossfit_games',
+                'divisions' => ['Women'],
+            ],
+        ], $payload['competitionContexts']);
     }
 
     public function testFrontendCanListPublicAthletesEvenWhenCatalogIsEmpty(): void


### PR DESCRIPTION
## Summary
- expose computed competition context on workout API payloads
- include competition name, season, event name/order, source and divisions
- add inverse Doctrine relations needed to derive the context without schema changes
- cover the API payload with an integration test

## Checks
- composer cs:check
- php -l src/Entity/Workout/Workout.php
- php -l src/Entity/Competition/CompetitionEvent.php
- php -l src/Entity/Competition/WorkoutResult.php
- php -l tests/WorkoutApiWorkflowTest.php
- DATABASE_URL=postgresql://app:***@127.0.0.1:5432/crossfit php bin/console doctrine:schema:validate --env=test
- DATABASE_URL=postgresql://app:***@127.0.0.1:5432/crossfit php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutApiWorkflowTest
- DATABASE_URL=postgresql://app:***@127.0.0.1:5432/crossfit php -d memory_limit=1G bin/phpunit --colors=always

Closes #101