### PR TITLE
Add public athlete AI analyses

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -35,6 +35,10 @@ services:
         arguments:
             $chatGPTApiKey: '%env(CHAT_GPT_API_KEY)%'
 
+    App\Services\Competition\AthletePublicAnalysisGenerator:
+        arguments:
+            $chatGPTApiKey: '%env(CHAT_GPT_API_KEY)%'
+
     App\Services\Workout\MovementDifficultyServiceInterface:
         class: App\Services\Workout\MovementDifficultyService
         public: true

--- a/migrations/Version20260514193000.php
+++ b/migrations/Version20260514193000.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260514193000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add stored public athlete analyses.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE athlete_public_analysis (id UUID NOT NULL, athlete_id UUID NOT NULL, kind VARCHAR(64) NOT NULL, prompt_hash VARCHAR(64) NOT NULL, analysis JSON NOT NULL, generated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_ATHLETE_PUBLIC_ANALYSIS_KIND ON athlete_public_analysis (athlete_id, kind)');
+        $this->addSql('CREATE INDEX IDX_477897E8FE6BCB8B ON athlete_public_analysis (athlete_id)');
+        $this->addSql('COMMENT ON COLUMN athlete_public_analysis.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN athlete_public_analysis.athlete_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN athlete_public_analysis.generated_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('COMMENT ON COLUMN athlete_public_analysis.created_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('COMMENT ON COLUMN athlete_public_analysis.updated_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE athlete_public_analysis ADD CONSTRAINT FK_ATHLETE_PUBLIC_ANALYSIS_ATHLETE FOREIGN KEY (athlete_id) REFERENCES athlete (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE athlete_public_analysis DROP CONSTRAINT FK_ATHLETE_PUBLIC_ANALYSIS_ATHLETE');
+        $this->addSql('DROP TABLE athlete_public_analysis');
+    }
+}

--- a/src/Command/GenerateAthletePublicAnalysesCommand.php
+++ b/src/Command/GenerateAthletePublicAnalysesCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Command;
+
+use App\Services\Competition\AthletePublicAnalysisGenerator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:athletes:generate-public-analyses',
+    description: 'Generate or refresh stored public AI analyses for CrossFit Games athletes.',
+)]
+final class GenerateAthletePublicAnalysesCommand extends Command
+{
+    public function __construct(private readonly AthletePublicAnalysisGenerator $generator)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum eligible athletes to inspect.', '25')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Regenerate even when a fresh analysis already exists.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $limit = max(1, (int) $input->getOption('limit'));
+        $force = (bool) $input->getOption('force');
+        $generated = 0;
+        $skipped = 0;
+        $failed = 0;
+
+        foreach ($this->generator->eligibleAthletes($limit) as $athlete) {
+            try {
+                if (!$force && !$this->generator->shouldGenerate($athlete)) {
+                    ++$skipped;
+                    continue;
+                }
+
+                $analysis = $force
+                    ? $this->generator->generate($athlete)
+                    : $this->generator->generateIfNeeded($athlete);
+
+                if ($analysis === null) {
+                    ++$skipped;
+                    continue;
+                }
+
+                ++$generated;
+                $io->writeln(sprintf('Generated %s', $athlete->getDisplayName()));
+            } catch (\Throwable $exception) {
+                ++$failed;
+                $io->warning(sprintf('%s: %s', $athlete->getDisplayName(), $exception->getMessage()));
+            }
+        }
+
+        $io->table(['generated', 'skipped', 'failed'], [[$generated, $skipped, $failed]]);
+
+        return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+}

--- a/src/Entity/Competition/Athlete.php
+++ b/src/Entity/Competition/Athlete.php
@@ -66,6 +66,9 @@ class Athlete
     #[ORM\OneToMany(mappedBy: 'athlete', targetEntity: UserAthleteProfile::class, orphanRemoval: true)]
     private Collection $linkedUserProfiles;
 
+    #[ORM\OneToMany(mappedBy: 'athlete', targetEntity: AthletePublicAnalysis::class, orphanRemoval: true)]
+    private Collection $publicAnalyses;
+
     public function __construct(string $displayName, string $sourceName, string $externalId)
     {
         $this->displayName = $displayName;
@@ -74,6 +77,7 @@ class Athlete
         $this->createdAt = new \DateTimeImmutable();
         $this->updatedAt = new \DateTimeImmutable();
         $this->linkedUserProfiles = new ArrayCollection();
+        $this->publicAnalyses = new ArrayCollection();
     }
 
     public function getId(): ?Uuid
@@ -179,10 +183,28 @@ class Athlete
         return $this->updatedAt;
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getPublicAnalysis(): ?array
+    {
+        $analysis = $this->publicAnalyses
+            ->filter(static fn (AthletePublicAnalysis $analysis): bool => $analysis->getKind() === AthletePublicAnalysis::KIND_GAMES_PUBLIC)
+            ->first();
+
+        return $analysis instanceof AthletePublicAnalysis ? $analysis->toPublicPayload() : null;
+    }
+
     #[Ignore]
     public function getLinkedUserProfiles(): Collection
     {
         return $this->linkedUserProfiles;
+    }
+
+    #[Ignore]
+    public function getPublicAnalyses(): Collection
+    {
+        return $this->publicAnalyses;
     }
 
     private function touch(): void

--- a/src/Entity/Competition/AthletePublicAnalysis.php
+++ b/src/Entity/Competition/AthletePublicAnalysis.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Entity\Competition;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'athlete_public_analysis')]
+#[ORM\UniqueConstraint(name: 'UNIQ_ATHLETE_PUBLIC_ANALYSIS_KIND', columns: ['athlete_id', 'kind'])]
+class AthletePublicAnalysis
+{
+    public const KIND_GAMES_PUBLIC = 'games_public_v1';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Athlete::class, inversedBy: 'publicAnalyses')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Athlete $athlete;
+
+    #[ORM\Column(length: 64)]
+    private string $kind;
+
+    #[ORM\Column(length: 64)]
+    private string $promptHash;
+
+    /**
+     * @var array<string, mixed>
+     */
+    #[ORM\Column(type: 'json')]
+    private array $analysis = [];
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $generatedAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $updatedAt;
+
+    /**
+     * @param array<string, mixed> $analysis
+     */
+    public function __construct(Athlete $athlete, string $kind, string $promptHash, array $analysis)
+    {
+        $this->athlete = $athlete;
+        $this->kind = $kind;
+        $this->promptHash = $promptHash;
+        $this->analysis = $analysis;
+        $this->generatedAt = new \DateTimeImmutable();
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getAthlete(): Athlete
+    {
+        return $this->athlete;
+    }
+
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+
+    public function getPromptHash(): string
+    {
+        return $this->promptHash;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getAnalysis(): array
+    {
+        return $this->analysis;
+    }
+
+    /**
+     * @param array<string, mixed> $analysis
+     */
+    public function replace(string $promptHash, array $analysis): self
+    {
+        $this->promptHash = $promptHash;
+        $this->analysis = $analysis;
+        $this->generatedAt = new \DateTimeImmutable();
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getGeneratedAt(): \DateTimeImmutable
+    {
+        return $this->generatedAt;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function isOlderThan(\DateInterval $maxAge): bool
+    {
+        return $this->generatedAt <= (new \DateTimeImmutable())->sub($maxAge);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPublicPayload(): array
+    {
+        return [
+            ...$this->analysis,
+            'generatedAt' => $this->generatedAt->format(\DateTimeInterface::ATOM),
+        ];
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+}

--- a/src/Services/Competition/AthletePublicAnalysisGenerator.php
+++ b/src/Services/Competition/AthletePublicAnalysisGenerator.php
@@ -250,10 +250,10 @@ final readonly class AthletePublicAnalysisGenerator
             $data = $response->toArray();
         } catch (
             ClientExceptionInterface
-            | DecodingExceptionInterface
-            | RedirectionExceptionInterface
-            | ServerExceptionInterface
-            | TransportExceptionInterface $exception
+            |DecodingExceptionInterface
+            |RedirectionExceptionInterface
+            |ServerExceptionInterface
+            |TransportExceptionInterface $exception
         ) {
             throw new \RuntimeException('OpenAI analysis request failed: '.$exception->getMessage(), 0, $exception);
         }

--- a/src/Services/Competition/AthletePublicAnalysisGenerator.php
+++ b/src/Services/Competition/AthletePublicAnalysisGenerator.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace App\Services\Competition;
+
+use App\Entity\Competition\Athlete;
+use App\Entity\Competition\AthletePublicAnalysis;
+use App\Entity\Competition\Competition;
+use App\Entity\Competition\WorkoutResult;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class AthletePublicAnalysisGenerator
+{
+    public const MAX_AGE = 'P6M';
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private HttpClientInterface $httpClient,
+        private string $chatGPTApiKey,
+        private string $openAiModel = 'gpt-4.1-mini',
+    ) {
+    }
+
+    public function shouldGenerate(Athlete $athlete): bool
+    {
+        if (!$this->isGamesAthlete($athlete)) {
+            return false;
+        }
+
+        $analysis = $this->existingAnalysis($athlete);
+
+        return $analysis === null || $analysis->isOlderThan(new \DateInterval(self::MAX_AGE));
+    }
+
+    public function generateIfNeeded(Athlete $athlete): ?AthletePublicAnalysis
+    {
+        if (!$this->shouldGenerate($athlete)) {
+            return $this->existingAnalysis($athlete);
+        }
+
+        return $this->generate($athlete);
+    }
+
+    public function generate(Athlete $athlete): ?AthletePublicAnalysis
+    {
+        $input = $this->analysisInput($athlete);
+        if ($input === []) {
+            return null;
+        }
+
+        $promptHash = $this->promptHash($athlete, $input);
+        $analysis = $this->requestAnalysis($athlete, $input);
+        $existing = $this->existingAnalysis($athlete);
+
+        if ($existing instanceof AthletePublicAnalysis) {
+            $existing->replace($promptHash, $analysis);
+            $row = $existing;
+        } else {
+            $row = new AthletePublicAnalysis(
+                $athlete,
+                AthletePublicAnalysis::KIND_GAMES_PUBLIC,
+                $promptHash,
+                $analysis,
+            );
+            $this->entityManager->persist($row);
+        }
+
+        $this->entityManager->flush();
+
+        return $row;
+    }
+
+    public function isGamesAthlete(Athlete $athlete): bool
+    {
+        $count = $this->entityManager->createQueryBuilder()
+            ->select('COUNT(result.id)')
+            ->from(WorkoutResult::class, 'result')
+            ->join('result.event', 'event')
+            ->join('event.competition', 'competition')
+            ->where('result.athlete = :athlete')
+            ->andWhere('competition.sourceName = :sourceName')
+            ->andWhere('LOWER(competition.name) LIKE :games')
+            ->andWhere('LOWER(competition.name) NOT LIKE :open')
+            ->setParameter('athlete', $athlete)
+            ->setParameter('sourceName', 'crossfit_games')
+            ->setParameter('games', '%games%')
+            ->setParameter('open', '%open%')
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $count > 0;
+    }
+
+    /**
+     * @return list<Athlete>
+     */
+    public function eligibleAthletes(int $limit = 25): array
+    {
+        return $this->entityManager->createQueryBuilder()
+            ->select('DISTINCT athlete')
+            ->from(Athlete::class, 'athlete')
+            ->join(WorkoutResult::class, 'result', 'WITH', 'result.athlete = athlete')
+            ->join('result.event', 'event')
+            ->join('event.competition', 'competition')
+            ->where('competition.sourceName = :sourceName')
+            ->andWhere('LOWER(competition.name) LIKE :games')
+            ->andWhere('LOWER(competition.name) NOT LIKE :open')
+            ->orderBy('athlete.displayName', 'ASC')
+            ->setMaxResults($limit)
+            ->setParameter('sourceName', 'crossfit_games')
+            ->setParameter('games', '%games%')
+            ->setParameter('open', '%open%')
+            ->getQuery()
+            ->getResult();
+    }
+
+    private function existingAnalysis(Athlete $athlete): ?AthletePublicAnalysis
+    {
+        return $this->entityManager->getRepository(AthletePublicAnalysis::class)->findOneBy([
+            'athlete' => $athlete,
+            'kind' => AthletePublicAnalysis::KIND_GAMES_PUBLIC,
+        ]);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function analysisInput(Athlete $athlete): array
+    {
+        $results = $this->entityManager->createQueryBuilder()
+            ->select('result', 'event', 'competition', 'score', 'workout', 'division')
+            ->from(WorkoutResult::class, 'result')
+            ->join('result.event', 'event')
+            ->join('event.competition', 'competition')
+            ->join('result.score', 'score')
+            ->leftJoin('event.workout', 'workout')
+            ->leftJoin('result.competitionDivision', 'division')
+            ->where('result.athlete = :athlete')
+            ->andWhere('competition.sourceName = :sourceName')
+            ->orderBy('competition.season', 'ASC')
+            ->addOrderBy('event.eventOrder', 'ASC')
+            ->setParameter('athlete', $athlete)
+            ->setParameter('sourceName', 'crossfit_games')
+            ->getQuery()
+            ->getResult();
+
+        $input = [];
+        foreach ($results as $result) {
+            if (!$result instanceof WorkoutResult) {
+                continue;
+            }
+
+            $competition = $result->getEvent()->getCompetition();
+            if (!$this->isRelevantCrossFitStage($competition)) {
+                continue;
+            }
+
+            $workout = $result->getEvent()->getWorkout();
+            $flow = $workout?->getFlow();
+            if ($flow === null || trim($flow) === '') {
+                continue;
+            }
+
+            $input[] = [
+                'competition' => $competition->getName(),
+                'season' => $competition->getSeason(),
+                'event' => $result->getEvent()->getName(),
+                'division' => $result->getCompetitionDivision()?->getName() ?? $result->getDivision(),
+                'rank' => $result->getRank(),
+                'score' => $result->getScore()->getDisplayValue() ?? $result->getScore()->getRawValue(),
+                'workout' => [
+                    'name' => $workout->getName(),
+                    'flow' => $flow,
+                    'movements' => array_map(
+                        static fn ($movement): ?string => method_exists($movement, 'getName') ? $movement->getName() : null,
+                        $workout->getMovements()->toArray(),
+                    ),
+                    'implements' => array_map(
+                        static fn ($implement): ?string => method_exists($implement, 'getName') ? $implement->getName() : null,
+                        $workout->getImplements()->toArray(),
+                    ),
+                ],
+            ];
+        }
+
+        return array_slice($input, -80);
+    }
+
+    private function isRelevantCrossFitStage(Competition $competition): bool
+    {
+        $name = strtolower($competition->getName());
+
+        return str_contains($name, 'games')
+            || str_contains($name, 'semifinal')
+            || str_contains($name, 'regional')
+            || str_contains($name, 'quarterfinal')
+            || str_contains($name, 'open');
+    }
+
+    /**
+     * @param list<array<string, mixed>> $input
+     *
+     * @return array<string, mixed>
+     */
+    private function requestAnalysis(Athlete $athlete, array $input): array
+    {
+        if ($this->chatGPTApiKey === '') {
+            throw new \RuntimeException('CHAT_GPT_API_KEY is required to generate athlete public analyses.');
+        }
+
+        $response = $this->httpClient->request('POST', 'https://api.openai.com/v1/chat/completions', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$this->chatGPTApiKey,
+                'Content-Type' => 'application/json',
+            ],
+            'json' => [
+                'model' => $this->openAiModel,
+                'response_format' => ['type' => 'json_object'],
+                'messages' => [
+                    [
+                        'role' => 'system',
+                        'content' => 'Tu es un coach CrossFit et analyste de performance. Analyse uniquement les donnees fournies, distingue les faits des hypotheses, et retourne uniquement un JSON valide en francais.',
+                    ],
+                    [
+                        'role' => 'user',
+                        'content' => json_encode([
+                            'task' => 'Produire une analyse publique courte pour teaser une analyse personnelle MonWOD.',
+                            'athlete' => $athlete->getDisplayName(),
+                            'results' => $input,
+                            'expected_schema' => [
+                                'summary' => 'string',
+                                'strengths' => ['string'],
+                                'weaknesses' => ['string'],
+                                'eventProfile' => ['string'],
+                                'trainingPriorities' => ['string'],
+                                'conclusion' => 'string',
+                            ],
+                        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE),
+                    ],
+                ],
+            ],
+        ]);
+
+        try {
+            $data = $response->toArray();
+        } catch (
+            ClientExceptionInterface
+            | DecodingExceptionInterface
+            | RedirectionExceptionInterface
+            | ServerExceptionInterface
+            | TransportExceptionInterface $exception
+        ) {
+            throw new \RuntimeException('OpenAI analysis request failed: '.$exception->getMessage(), 0, $exception);
+        }
+
+        $content = $data['choices'][0]['message']['content'] ?? '{}';
+        $analysis = json_decode((string) $content, true);
+
+        if (!is_array($analysis)) {
+            throw new \RuntimeException('OpenAI analysis response is not a JSON object.');
+        }
+
+        return [
+            'kind' => AthletePublicAnalysis::KIND_GAMES_PUBLIC,
+            'model' => $this->openAiModel,
+            ...$analysis,
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $input
+     */
+    private function promptHash(Athlete $athlete, array $input): string
+    {
+        return hash('sha256', json_encode([
+            'kind' => AthletePublicAnalysis::KIND_GAMES_PUBLIC,
+            'athlete' => $athlete->getDisplayName(),
+            'input' => $input,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE));
+    }
+}

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -4,6 +4,7 @@ namespace App\Tests;
 
 use App\DataFixtures\WorkoutData;
 use App\Entity\Competition\Athlete;
+use App\Entity\Competition\AthletePublicAnalysis;
 use App\Entity\Competition\Competition;
 use App\Entity\Competition\CompetitionDivision;
 use App\Entity\Competition\CompetitionEvent;
@@ -99,6 +100,36 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
 
         self::assertContains('Tia-Clair Toomey', $names);
         self::assertNotContains('Mat Fraser', $names);
+    }
+
+    public function testFrontendCanReadStoredPublicAthleteAnalysis(): void
+    {
+        $entityManager = $this->getEntityManager();
+        $athlete = new Athlete('Tia-Clair Toomey', 'crossfit_games', 'tia-analysis');
+        $analysis = new AthletePublicAnalysis($athlete, AthletePublicAnalysis::KIND_GAMES_PUBLIC, 'hash', [
+            'summary' => 'Dominant Games profile.',
+            'strengths' => ['Engine under fatigue'],
+            'weaknesses' => ['Limited weaknesses in imported data'],
+            'eventProfile' => ['Strong across mixed modal events'],
+            'trainingPriorities' => ['Keep high-skill volume healthy'],
+            'conclusion' => 'A benchmark athlete for public teaser analysis.',
+            'model' => 'test-model',
+        ]);
+
+        $entityManager->persist($athlete);
+        $entityManager->persist($analysis);
+        $entityManager->flush();
+        $entityManager->clear();
+
+        $this->browser()->request('GET', sprintf('/api/athletes/%s', $athlete->getId()));
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('Dominant Games profile.', $payload['publicAnalysis']['summary']);
+        self::assertSame(['Engine under fatigue'], $payload['publicAnalysis']['strengths']);
+        self::assertArrayHasKey('generatedAt', $payload['publicAnalysis']);
     }
 
     public function testFrontendCanFilterWorkoutResultsByAthleteIri(): void


### PR DESCRIPTION
## Summary
- add stored public athlete analyses with generation timestamp
- expose the stored analysis as publicAnalysis on athlete API payloads
- add an idempotent command to generate or refresh analyses for CrossFit Games athletes
- refresh analyses after six months, or with --force

## Usage
php bin/console doctrine:migrations:migrate --no-interaction
php bin/console app:athletes:generate-public-analyses --limit=25

## Tests
- phpunit --filter WorkoutApiWorkflowTest
- doctrine:schema:validate --env=test
- app:athletes:generate-public-analyses --env=test --limit=1

Closes #100.