### PR TITLE
Expose athlete avatar URLs

### DIFF
--- a/migrations/Version20260514211500.php
+++ b/migrations/Version20260514211500.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260514211500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add avatar URL to imported athletes.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE athlete ADD avatar_url VARCHAR(2048) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE athlete DROP avatar_url');
+    }
+}

--- a/src/Command/ImportCompetitionResultsCommand.php
+++ b/src/Command/ImportCompetitionResultsCommand.php
@@ -250,7 +250,8 @@ class ImportCompetitionResultsCommand extends Command
             ->setLastName($this->stringOrNull($row['lastName'] ?? null))
             ->setGender($this->stringOrNull($row['gender'] ?? null))
             ->setCountry($this->stringOrNull($row['country'] ?? null))
-            ->setSourceUrl($sourceUrl);
+            ->setSourceUrl($sourceUrl)
+            ->setAvatarUrl($this->stringOrNull($row['avatarUrl'] ?? null));
 
         return $status;
     }

--- a/src/Entity/Competition/Athlete.php
+++ b/src/Entity/Competition/Athlete.php
@@ -57,6 +57,9 @@ class Athlete
     #[ORM\Column(length: 2048, nullable: true)]
     private ?string $sourceUrl = null;
 
+    #[ORM\Column(length: 2048, nullable: true)]
+    private ?string $avatarUrl = null;
+
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
 
@@ -168,6 +171,19 @@ class Athlete
     public function setSourceUrl(?string $sourceUrl): self
     {
         $this->sourceUrl = $sourceUrl;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getAvatarUrl(): ?string
+    {
+        return $this->avatarUrl;
+    }
+
+    public function setAvatarUrl(?string $avatarUrl): self
+    {
+        $this->avatarUrl = $avatarUrl;
         $this->touch();
 
         return $this;

--- a/tests/ImportCompetitionResultsCommandTest.php
+++ b/tests/ImportCompetitionResultsCommandTest.php
@@ -79,7 +79,11 @@ class ImportCompetitionResultsCommandTest extends AbstractIntegrationTest
                 ],
             ],
             'athletes' => [
-                ['source' => ['externalId' => 'athlete-1'], 'displayName' => 'Athlete One'],
+                [
+                    'source' => ['externalId' => 'athlete-1'],
+                    'displayName' => 'Athlete One',
+                    'avatarUrl' => 'https://profilepicsbucket.crossfit.com/athlete-one.jpg',
+                ],
                 ['source' => ['externalId' => 'athlete-2'], 'displayName' => 'Athlete Two'],
             ],
             'competitions' => [
@@ -134,6 +138,14 @@ class ImportCompetitionResultsCommandTest extends AbstractIntegrationTest
             self::assertCount(2, $results);
             self::assertSame((string) $divisions[0]->getId(), (string) $results[0]->getCompetitionDivision()?->getId());
             self::assertSame((string) $divisions[0]->getId(), (string) $results[1]->getCompetitionDivision()?->getId());
+
+            /** @var Athlete|null $athlete */
+            $athlete = $this->getRepository(Athlete::class)->findOneBy([
+                'sourceName' => 'crossfit_games',
+                'externalId' => 'athlete-1',
+            ]);
+            self::assertNotNull($athlete);
+            self::assertSame('https://profilepicsbucket.crossfit.com/athlete-one.jpg', $athlete->getAvatarUrl());
         } finally {
             @unlink($file);
         }

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -86,7 +86,10 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
     public function testFrontendCanSearchAthletesByDisplayName(): void
     {
         $entityManager = $this->getEntityManager();
-        $entityManager->persist(new Athlete('Tia-Clair Toomey', 'crossfit_games', 'tia-toomey'));
+        $entityManager->persist(
+            (new Athlete('Tia-Clair Toomey', 'crossfit_games', 'tia-toomey'))
+                ->setAvatarUrl('https://profilepicsbucket.crossfit.com/tia.jpg')
+        );
         $entityManager->persist(new Athlete('Mat Fraser', 'crossfit_games', 'mat-fraser'));
         $entityManager->flush();
 
@@ -100,6 +103,7 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
 
         self::assertContains('Tia-Clair Toomey', $names);
         self::assertNotContains('Mat Fraser', $names);
+        self::assertSame('https://profilepicsbucket.crossfit.com/tia.jpg', $athletes[0]['avatarUrl']);
     }
 
     public function testFrontendCanReadStoredPublicAthleteAnalysis(): void


### PR DESCRIPTION
## Summary
- add nullable avatarUrl storage on imported athletes
- import avatarUrl from the analyser payload
- expose avatarUrl through the athlete API resource

## Tests
- composer cs:check
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php bin/console doctrine:schema:validate --env=test
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter ImportCompetitionResultsCommandTest
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutApiWorkflowTest