### PR TITLE
Expose result field sizes

### DIFF
--- a/migrations/Version20260515094500.php
+++ b/migrations/Version20260515094500.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260515094500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add field size to imported workout results.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE workout_result ADD field_size INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE workout_result DROP field_size');
+    }
+}

--- a/src/Command/ImportCompetitionResultsCommand.php
+++ b/src/Command/ImportCompetitionResultsCommand.php
@@ -348,6 +348,7 @@ class ImportCompetitionResultsCommand extends Command
         $result
             ->setScore($score)
             ->setRank($this->intOrNull($row['rank'] ?? null))
+            ->setFieldSize($this->intOrNull($row['fieldSize'] ?? null))
             ->setDivision($divisionName)
             ->setCompetitionDivision($competitionDivision)
             ->setPoints($this->intOrNull($row['points'] ?? null))

--- a/src/Entity/Competition/WorkoutResult.php
+++ b/src/Entity/Competition/WorkoutResult.php
@@ -53,6 +53,9 @@ class WorkoutResult
     #[ORM\Column(nullable: true)]
     private ?int $rank = null;
 
+    #[ORM\Column(nullable: true)]
+    private ?int $fieldSize = null;
+
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $division = null;
 
@@ -139,6 +142,19 @@ class WorkoutResult
     public function setRank(?int $rank): self
     {
         $this->rank = $rank;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getFieldSize(): ?int
+    {
+        return $this->fieldSize;
+    }
+
+    public function setFieldSize(?int $fieldSize): self
+    {
+        $this->fieldSize = $fieldSize;
         $this->touch();
 
         return $this;

--- a/tests/ImportCompetitionResultsCommandTest.php
+++ b/tests/ImportCompetitionResultsCommandTest.php
@@ -108,6 +108,7 @@ class ImportCompetitionResultsCommandTest extends AbstractIntegrationTest
                     'athleteSourceId' => 'athlete-1',
                     'eventSourceId' => 'games-2024-event-1-women',
                     'rank' => 1,
+                    'fieldSize' => 40,
                     'division' => 'Women',
                     'score' => ['type' => 'time', 'rawValue' => '10:00', 'displayValue' => '10:00', 'timeInSeconds' => 600],
                 ],
@@ -138,6 +139,7 @@ class ImportCompetitionResultsCommandTest extends AbstractIntegrationTest
             self::assertCount(2, $results);
             self::assertSame((string) $divisions[0]->getId(), (string) $results[0]->getCompetitionDivision()?->getId());
             self::assertSame((string) $divisions[0]->getId(), (string) $results[1]->getCompetitionDivision()?->getId());
+            self::assertSame(40, $results[0]->getFieldSize());
 
             /** @var Athlete|null $athlete */
             $athlete = $this->getRepository(Athlete::class)->findOneBy([

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -147,7 +147,8 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         $division = new CompetitionDivision($competition, 'Women', 'crossfit_games', 'games-2017-women');
         $tiaResult = (new WorkoutResult($tia, $event, new Score(ScoreTypeEnum::TIME, '6:35'), 'crossfit_games', 'tia-17-5'))
             ->setCompetitionDivision($division)
-            ->setRank(1);
+            ->setRank(1)
+            ->setFieldSize(40);
         $matResult = (new WorkoutResult($mat, $event, new Score(ScoreTypeEnum::TIME, '6:24'), 'crossfit_games', 'mat-17-5'))
             ->setRank(1);
 
@@ -166,6 +167,7 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         self::assertCount(1, $results);
         self::assertSame('/api/athletes/'.$tia->getId(), $results[0]['athlete']);
         self::assertSame(1, $results[0]['rank']);
+        self::assertSame(40, $results[0]['fieldSize']);
     }
 
     public function testPublicWorkoutCatalogIsReadOnly(): void


### PR DESCRIPTION
## Summary
- add nullable fieldSize storage on workout results
- import fieldSize from analyser payloads
- expose fieldSize through the workout result API resource

## Tests
- composer cs:check

## Notes
- Local Docker/PostgreSQL was not running, so DB-backed PHPUnit/schema checks could not be executed locally.