### PR TITLE
Rank athlete catalog by elite Games results

### DIFF
--- a/migrations/Version20260515113000.php
+++ b/migrations/Version20260515113000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260515113000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add latest elite Games ranking fields to athletes.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE athlete ADD elite_games_rank INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE athlete ADD elite_games_season INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE athlete ADD elite_games_sort_score INT DEFAULT 2147483647 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE athlete DROP elite_games_rank');
+        $this->addSql('ALTER TABLE athlete DROP elite_games_season');
+        $this->addSql('ALTER TABLE athlete DROP elite_games_sort_score');
+    }
+}

--- a/src/Command/ImportCompetitionResultsCommand.php
+++ b/src/Command/ImportCompetitionResultsCommand.php
@@ -251,7 +251,9 @@ class ImportCompetitionResultsCommand extends Command
             ->setGender($this->stringOrNull($row['gender'] ?? null))
             ->setCountry($this->stringOrNull($row['country'] ?? null))
             ->setSourceUrl($sourceUrl)
-            ->setAvatarUrl($this->stringOrNull($row['avatarUrl'] ?? null));
+            ->setAvatarUrl($this->stringOrNull($row['avatarUrl'] ?? null))
+            ->setEliteGamesRank($this->intOrNull($row['eliteGamesRank'] ?? null))
+            ->setEliteGamesSeason($this->intOrNull($row['eliteGamesSeason'] ?? null));
 
         return $status;
     }

--- a/src/Entity/Competition/Athlete.php
+++ b/src/Entity/Competition/Athlete.php
@@ -17,7 +17,10 @@ use Symfony\Component\Uid\Uuid;
 #[ORM\Entity]
 #[ORM\Table(name: 'athlete')]
 #[ORM\UniqueConstraint(name: 'UNIQ_ATHLETE_SOURCE_EXTERNAL', columns: ['source_name', 'external_id'])]
-#[ApiResource(operations: [new Get(), new GetCollection()])]
+#[ApiResource(operations: [new Get(), new GetCollection()], order: [
+    'eliteGamesSortScore' => 'ASC',
+    'displayName' => 'ASC',
+])]
 #[ApiFilter(SearchFilter::class, properties: [
     'displayName' => 'ipartial',
     'firstName' => 'ipartial',
@@ -59,6 +62,15 @@ class Athlete
 
     #[ORM\Column(length: 2048, nullable: true)]
     private ?string $avatarUrl = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $eliteGamesRank = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $eliteGamesSeason = null;
+
+    #[ORM\Column(options: ['default' => 2147483647])]
+    private int $eliteGamesSortScore = 2147483647;
 
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
@@ -189,6 +201,34 @@ class Athlete
         return $this;
     }
 
+    public function getEliteGamesRank(): ?int
+    {
+        return $this->eliteGamesRank;
+    }
+
+    public function setEliteGamesRank(?int $eliteGamesRank): self
+    {
+        $this->eliteGamesRank = $eliteGamesRank;
+        $this->refreshEliteGamesSortScore();
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getEliteGamesSeason(): ?int
+    {
+        return $this->eliteGamesSeason;
+    }
+
+    public function setEliteGamesSeason(?int $eliteGamesSeason): self
+    {
+        $this->eliteGamesSeason = $eliteGamesSeason;
+        $this->refreshEliteGamesSortScore();
+        $this->touch();
+
+        return $this;
+    }
+
     public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->createdAt;
@@ -226,5 +266,16 @@ class Athlete
     private function touch(): void
     {
         $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    private function refreshEliteGamesSortScore(): void
+    {
+        if ($this->eliteGamesRank === null || $this->eliteGamesSeason === null) {
+            $this->eliteGamesSortScore = 2147483647;
+
+            return;
+        }
+
+        $this->eliteGamesSortScore = max(0, 9999 - $this->eliteGamesSeason) * 10000 + $this->eliteGamesRank;
     }
 }

--- a/tests/ImportCompetitionResultsCommandTest.php
+++ b/tests/ImportCompetitionResultsCommandTest.php
@@ -83,6 +83,8 @@ class ImportCompetitionResultsCommandTest extends AbstractIntegrationTest
                     'source' => ['externalId' => 'athlete-1'],
                     'displayName' => 'Athlete One',
                     'avatarUrl' => 'https://profilepicsbucket.crossfit.com/athlete-one.jpg',
+                    'eliteGamesRank' => 1,
+                    'eliteGamesSeason' => 2024,
                 ],
                 ['source' => ['externalId' => 'athlete-2'], 'displayName' => 'Athlete Two'],
             ],
@@ -148,6 +150,8 @@ class ImportCompetitionResultsCommandTest extends AbstractIntegrationTest
             ]);
             self::assertNotNull($athlete);
             self::assertSame('https://profilepicsbucket.crossfit.com/athlete-one.jpg', $athlete->getAvatarUrl());
+            self::assertSame(1, $athlete->getEliteGamesRank());
+            self::assertSame(2024, $athlete->getEliteGamesSeason());
         } finally {
             @unlink($file);
         }

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -106,6 +106,45 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         self::assertSame('https://profilepicsbucket.crossfit.com/tia.jpg', $athletes[0]['avatarUrl']);
     }
 
+    public function testFrontendListsLatestEliteGamesAthletesFirst(): void
+    {
+        $entityManager = $this->getEntityManager();
+        $entityManager->persist(
+            new Athlete('Alphabetical Athlete', 'competition_corner', 'local-athlete')
+        );
+        $entityManager->persist(
+            (new Athlete('Former Champion', 'crossfit_games', 'former-champion'))
+                ->setEliteGamesSeason(2023)
+                ->setEliteGamesRank(1)
+        );
+        $entityManager->persist(
+            (new Athlete('Recent Runner Up', 'crossfit_games', 'recent-runner-up'))
+                ->setEliteGamesSeason(2025)
+                ->setEliteGamesRank(2)
+        );
+        $entityManager->persist(
+            (new Athlete('Recent Champion', 'crossfit_games', 'recent-champion'))
+                ->setEliteGamesSeason(2025)
+                ->setEliteGamesRank(1)
+        );
+        $entityManager->flush();
+
+        $this->browser()->request('GET', '/api/athletes');
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $athletes = $payload['member'] ?? $payload['hydra:member'] ?? [];
+        $names = array_map(static fn (array $athlete): ?string => $athlete['displayName'] ?? null, $athletes);
+
+        self::assertSame(
+            ['Recent Champion', 'Recent Runner Up', 'Former Champion', 'Alphabetical Athlete'],
+            array_slice($names, 0, 4),
+        );
+        self::assertSame(1, $athletes[0]['eliteGamesRank']);
+        self::assertSame(2025, $athletes[0]['eliteGamesSeason']);
+    }
+
     public function testFrontendCanReadStoredPublicAthleteAnalysis(): void
     {
         $entityManager = $this->getEntityManager();


### PR DESCRIPTION
## Summary
- store latest Individual Elite Games rank and season on imported athletes
- add a migration for the new ranking fields and stable sort score
- order `/api/athletes` by recent Elite Games ranking before display name

## Tests
- `php -l src/Entity/Competition/Athlete.php`
- `php -l src/Command/ImportCompetitionResultsCommand.php`
- `php -l migrations/Version20260515113000.php`

Integration tests could not complete locally because PostgreSQL on 127.0.0.1:5432 refused the connection.