### PR TITLE
Add compact athlete result summary endpoint

### DIFF
--- a/src/Controller/Competition/AthletePublicAnalysisController.php
+++ b/src/Controller/Competition/AthletePublicAnalysisController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Controller\Competition;
+
+use App\Entity\Competition\Athlete;
+use App\Services\Competition\AthletePublicAnalysisGenerator;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class AthletePublicAnalysisController extends AbstractController
+{
+    #[Route('/api/athletes/{id}/public-analysis', name: 'api_athlete_public_analysis_generate', methods: ['POST'])]
+    public function __invoke(
+        string $id,
+        EntityManagerInterface $entityManager,
+        AthletePublicAnalysisGenerator $generator,
+    ): JsonResponse {
+        $athlete = $entityManager->getRepository(Athlete::class)->find($id);
+
+        if (!$athlete instanceof Athlete) {
+            throw new NotFoundHttpException('Athlete not found.');
+        }
+
+        $analysis = $generator->generateIfNeeded($athlete);
+
+        if ($analysis === null) {
+            return $this->json([
+                'analysis' => null,
+                'eligible' => false,
+            ]);
+        }
+
+        return $this->json([
+            'analysis' => $analysis->toPublicPayload(),
+            'eligible' => true,
+        ]);
+    }
+}

--- a/src/Controller/Competition/AthleteResultSummaryController.php
+++ b/src/Controller/Competition/AthleteResultSummaryController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Controller\Competition;
+
+use App\Entity\Competition\Athlete;
+use App\Entity\Competition\WorkoutResult;
+use App\Entity\Workout\Workout;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class AthleteResultSummaryController extends AbstractController
+{
+    #[Route('/api/athletes/{id}/result-summary', name: 'api_athlete_result_summary', methods: ['GET'])]
+    public function __invoke(string $id, EntityManagerInterface $entityManager): JsonResponse
+    {
+        $athlete = $entityManager->getRepository(Athlete::class)->find($id);
+
+        if (!$athlete instanceof Athlete) {
+            throw new NotFoundHttpException('Athlete not found.');
+        }
+
+        $relatedAthletes = $entityManager->getRepository(Athlete::class)->findBy([
+            'displayName' => $athlete->getDisplayName(),
+        ]);
+
+        $results = $entityManager->createQueryBuilder()
+            ->select('result', 'score', 'event', 'competition', 'division', 'workout')
+            ->from(WorkoutResult::class, 'result')
+            ->join('result.score', 'score')
+            ->join('result.event', 'event')
+            ->join('event.competition', 'competition')
+            ->leftJoin('result.competitionDivision', 'division')
+            ->leftJoin('event.workout', 'workout')
+            ->andWhere('result.athlete IN (:athletes)')
+            ->setParameter('athletes', $relatedAthletes)
+            ->orderBy('result.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return $this->json([
+            'totalItems' => count($results),
+            'member' => array_map([$this, 'resultPayload'], $results),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resultPayload(WorkoutResult $result): array
+    {
+        $event = $result->getEvent();
+        $competition = $event->getCompetition();
+        $division = $result->getCompetitionDivision();
+        $score = $result->getScore();
+        $workout = $event->getWorkout();
+
+        return [
+            '@id' => '/api/workout_results/'.$result->getId(),
+            'id' => (string) $result->getId(),
+            'athlete' => '/api/athletes/'.$result->getAthlete()->getId(),
+            'event' => '/api/competition_events/'.$event->getId(),
+            'competitionDivision' => $division ? '/api/competition_divisions/'.$division->getId() : null,
+            'score' => '/api/scores/'.$score->getId(),
+            'rank' => $result->getRank(),
+            'fieldSize' => $result->getFieldSize(),
+            'division' => $result->getDivision(),
+            'points' => $result->getPoints(),
+            'sourceName' => $result->getSourceName(),
+            'externalId' => $result->getExternalId(),
+            'sourceUrl' => $result->getSourceUrl(),
+            'createdAt' => $result->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            'updatedAt' => $result->getUpdatedAt()->format(\DateTimeInterface::ATOM),
+            'scoreDetails' => [
+                '@id' => '/api/scores/'.$score->getId(),
+                'id' => (string) $score->getId(),
+                'type' => $score->getType()->value,
+                'rawValue' => $score->getRawValue(),
+                'displayValue' => $score->getDisplayValue(),
+                'numericValue' => $score->getNumericValue(),
+                'timeInSeconds' => $score->getTimeInSeconds(),
+                'unit' => $score->getUnit(),
+            ],
+            'eventDetails' => [
+                '@id' => '/api/competition_events/'.$event->getId(),
+                'id' => (string) $event->getId(),
+                'competition' => '/api/competitions/'.$competition->getId(),
+                'workout' => $workout instanceof Workout ? '/api/workouts/'.$workout->getId() : null,
+                'name' => $event->getName(),
+                'sourceName' => $event->getSourceName(),
+                'externalId' => $event->getExternalId(),
+                'sourceUrl' => $event->getSourceUrl(),
+            ],
+            'competitionDetails' => [
+                '@id' => '/api/competitions/'.$competition->getId(),
+                'id' => (string) $competition->getId(),
+                'name' => $competition->getName(),
+                'season' => $competition->getSeason(),
+                'sourceName' => $competition->getSourceName(),
+                'externalId' => $competition->getExternalId(),
+                'sourceUrl' => $competition->getSourceUrl(),
+            ],
+            'competitionDivisionDetails' => $division ? [
+                '@id' => '/api/competition_divisions/'.$division->getId(),
+                'id' => (string) $division->getId(),
+                'competition' => '/api/competitions/'.$division->getCompetition()->getId(),
+                'name' => $division->getName(),
+                'sourceName' => $division->getSourceName(),
+                'externalId' => $division->getExternalId(),
+                'sourceUrl' => $division->getSourceUrl(),
+            ] : null,
+            'workoutDetails' => $workout instanceof Workout ? [
+                '@id' => '/api/workouts/'.$workout->getId(),
+                'id' => (string) $workout->getId(),
+                'name' => $workout->getName(),
+                'flow' => $workout->getFlow(),
+                'sourceName' => $workout->getSourceName(),
+                'externalId' => $workout->getExternalId(),
+                'sourceUrl' => $workout->getSourceUrl(),
+            ] : null,
+        ];
+    }
+}

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -175,6 +175,51 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         self::assertArrayHasKey('generatedAt', $payload['publicAnalysis']);
     }
 
+    public function testFrontendCanRequestExistingPublicAthleteAnalysis(): void
+    {
+        $entityManager = $this->getEntityManager();
+        $athlete = new Athlete('Tia-Clair Toomey', 'crossfit_games', 'tia-analysis-request');
+        $analysis = new AthletePublicAnalysis($athlete, AthletePublicAnalysis::KIND_GAMES_PUBLIC, 'hash', [
+            'summary' => 'Existing Games profile.',
+            'strengths' => ['Complete athlete'],
+            'model' => 'test-model',
+        ]);
+
+        $entityManager->persist($athlete);
+        $entityManager->persist($analysis);
+        $entityManager->flush();
+        $entityManager->clear();
+
+        $this->browser()->request('POST', sprintf('/api/athletes/%s/public-analysis', $athlete->getId()));
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertTrue($payload['eligible']);
+        self::assertSame('Existing Games profile.', $payload['analysis']['summary']);
+        self::assertSame(['Complete athlete'], $payload['analysis']['strengths']);
+    }
+
+    public function testFrontendDoesNotGeneratePublicAnalysisForNonGamesAthlete(): void
+    {
+        $entityManager = $this->getEntityManager();
+        $athlete = new Athlete('Local Athlete', 'competition_corner', 'local-athlete-analysis');
+
+        $entityManager->persist($athlete);
+        $entityManager->flush();
+        $entityManager->clear();
+
+        $this->browser()->request('POST', sprintf('/api/athletes/%s/public-analysis', $athlete->getId()));
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertFalse($payload['eligible']);
+        self::assertNull($payload['analysis']);
+    }
+
     public function testFrontendCanFilterWorkoutResultsByAthleteIri(): void
     {
         $entityManager = $this->getEntityManager();
@@ -258,7 +303,7 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         self::assertCount(2, $payload['member']);
         self::assertSame('2019 Games', $payload['member'][0]['competitionDetails']['name']);
         self::assertSame('Event 1', $payload['member'][0]['eventDetails']['name']);
-        self::assertSame('17.5', $payload['member'][0]['workoutDetails']['name']);
+        self::assertSame('Open 17.5', $payload['member'][0]['workoutDetails']['name']);
         self::assertArrayHasKey('scoreDetails', $payload['member'][0]);
         self::assertContains('/api/athletes/'.$cornerProfile->getId(), array_column($payload['member'], 'athlete'));
         self::assertNotContains('/api/athletes/'.$otherAthlete->getId(), array_column($payload['member'], 'athlete'));

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -209,6 +209,61 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         self::assertSame(40, $results[0]['fieldSize']);
     }
 
+    public function testFrontendCanReadCompactAthleteResultSummary(): void
+    {
+        $entityManager = $this->getEntityManager();
+        /** @var Workout $workout */
+        $workout = $this->getReference(WorkoutData::WORKOUT_OPEN_17_5, Workout::class);
+        $gamesProfile = new Athlete('Sabrina Caron', 'crossfit_games', 'sabrina-games');
+        $cornerProfile = new Athlete('Sabrina Caron', 'competition_corner', 'sabrina-corner');
+        $otherAthlete = new Athlete('Other Athlete', 'crossfit_games', 'other-athlete');
+        $competition = (new Competition('2019 Games', 'crossfit_games', 'games-2019'))
+            ->setSeason(2019);
+        $event = (new CompetitionEvent($competition, 'Event 1', 'crossfit_games', 'games-2019-event-1'))
+            ->setWorkout($workout);
+        $division = new CompetitionDivision($competition, 'Women', 'crossfit_games', 'games-2019-women');
+        $gamesResult = (new WorkoutResult($gamesProfile, $event, new Score(ScoreTypeEnum::TIME, '8:21'), 'crossfit_games', 'sabrina-games-event-1'))
+            ->setCompetitionDivision($division)
+            ->setRank(12)
+            ->setFieldSize(40);
+        $cornerResult = (new WorkoutResult($cornerProfile, $event, new Score(ScoreTypeEnum::REPS, '127'), 'competition_corner', 'sabrina-corner-event-1'))
+            ->setCompetitionDivision($division)
+            ->setRank(2)
+            ->setFieldSize(18);
+        $otherResult = new WorkoutResult($otherAthlete, $event, new Score(ScoreTypeEnum::TIME, '7:55'), 'crossfit_games', 'other-event-1');
+
+        foreach ([
+            $gamesProfile,
+            $cornerProfile,
+            $otherAthlete,
+            $competition,
+            $event,
+            $division,
+            $gamesResult,
+            $cornerResult,
+            $otherResult,
+        ] as $entity) {
+            $entityManager->persist($entity);
+        }
+        $entityManager->flush();
+        $entityManager->clear();
+
+        $this->browser()->request('GET', sprintf('/api/athletes/%s/result-summary', $gamesProfile->getId()));
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(2, $payload['totalItems']);
+        self::assertCount(2, $payload['member']);
+        self::assertSame('2019 Games', $payload['member'][0]['competitionDetails']['name']);
+        self::assertSame('Event 1', $payload['member'][0]['eventDetails']['name']);
+        self::assertSame('17.5', $payload['member'][0]['workoutDetails']['name']);
+        self::assertArrayHasKey('scoreDetails', $payload['member'][0]);
+        self::assertContains('/api/athletes/'.$cornerProfile->getId(), array_column($payload['member'], 'athlete'));
+        self::assertNotContains('/api/athletes/'.$otherAthlete->getId(), array_column($payload['member'], 'athlete'));
+    }
+
     public function testPublicWorkoutCatalogIsReadOnly(): void
     {
         $this->browser()->request(


### PR DESCRIPTION
## Summary
- add a compact athlete result summary endpoint with score, event, competition, division, and workout data joined server-side
- include same-display-name athlete profiles in the payload so athlete detail pages keep aggregated results
- cover the endpoint with an integration test

## Tests
- php -l src/Controller/Competition/AthleteResultSummaryController.php
- php bin/console debug:router api_athlete_result_summary --env=test
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutApiWorkflowTest *(fails locally: PostgreSQL on 127.0.0.1:5432 is not running)*