### PR TITLE
Expose public analysis generation failures

### DIFF
--- a/src/Controller/Competition/AthletePublicAnalysisController.php
+++ b/src/Controller/Competition/AthletePublicAnalysisController.php
@@ -26,7 +26,7 @@ final class AthletePublicAnalysisController extends AbstractController
 
         try {
             $analysis = $generator->generateIfNeeded($athlete);
-        } catch (\RuntimeException $exception) {
+        } catch (\Throwable $exception) {
             return $this->json([
                 'analysis' => null,
                 'eligible' => true,


### PR DESCRIPTION
## Summary
- catch all generation failures on the on-demand public athlete analysis endpoint
- return a 503 JSON payload with the generation error so production issues are diagnosable from the frontend/API

## Tests
- php -l src/Controller/Competition/AthletePublicAnalysisController.php