### PR TITLE
Backfill CrossFit Games athlete photos

### DIFF
--- a/src/Command/BackfillCrossFitGamesAthletePhotosCommand.php
+++ b/src/Command/BackfillCrossFitGamesAthletePhotosCommand.php
@@ -111,6 +111,7 @@ final class BackfillCrossFitGamesAthletePhotosCommand extends Command
     private function fetchAvatarUrl(Athlete $athlete): ?string
     {
         $profileUrl = $athlete->getSourceUrl() ?: sprintf('https://games.crossfit.com/athlete/%s', $athlete->getExternalId());
+
         return $this->photoFetcher->fetch($profileUrl);
     }
 }

--- a/src/Command/BackfillCrossFitGamesAthletePhotosCommand.php
+++ b/src/Command/BackfillCrossFitGamesAthletePhotosCommand.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Competition\Athlete;
+use App\Services\Competition\CrossFitGamesProfilePhotoFetcher;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:athletes:backfill-games-photos',
+    description: 'Backfill missing CrossFit Games athlete photos directly into Symfony athletes.',
+)]
+final class BackfillCrossFitGamesAthletePhotosCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly CrossFitGamesProfilePhotoFetcher $photoFetcher,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum athletes to inspect.', '50')
+            ->addOption('external-id', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Only inspect one CrossFit Games athlete external id. Can be passed multiple times.')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Refresh photos even when avatar_url is already present.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Fetch photos and print what would change without writing to the database.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $limit = max(1, (int) $input->getOption('limit'));
+        $externalIds = array_values(array_filter(array_map('strval', (array) $input->getOption('external-id'))));
+        $force = (bool) $input->getOption('force');
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        $inspected = 0;
+        $updated = 0;
+        $missing = 0;
+        $failed = 0;
+
+        foreach ($this->findAthletes($limit, $externalIds, $force) as $athlete) {
+            ++$inspected;
+
+            try {
+                $avatarUrl = $this->fetchAvatarUrl($athlete);
+            } catch (\Throwable $exception) {
+                ++$failed;
+                $io->warning(sprintf('%s (%s): %s', $athlete->getDisplayName(), $athlete->getExternalId(), $exception->getMessage()));
+                continue;
+            }
+
+            if ($avatarUrl === null) {
+                ++$missing;
+                $io->writeln(sprintf('Missing %s (%s)', $athlete->getDisplayName(), $athlete->getExternalId()));
+                continue;
+            }
+
+            $io->writeln(sprintf('Photo %s (%s): %s', $athlete->getDisplayName(), $athlete->getExternalId(), $avatarUrl));
+            if (!$dryRun) {
+                $athlete->setAvatarUrl($avatarUrl);
+                ++$updated;
+            }
+        }
+
+        if ($updated > 0 && !$dryRun) {
+            $this->entityManager->flush();
+        }
+
+        $io->table(
+            ['inspected', 'updated', 'missing', 'failed'],
+            [[$inspected, $updated, $missing, $failed]],
+        );
+
+        return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * @param list<string> $externalIds
+     *
+     * @return list<Athlete>
+     */
+    private function findAthletes(int $limit, array $externalIds, bool $force): array
+    {
+        $queryBuilder = $this->entityManager->getRepository(Athlete::class)->createQueryBuilder('athlete')
+            ->andWhere('athlete.sourceName = :sourceName')
+            ->setParameter('sourceName', 'crossfit_games')
+            ->orderBy('athlete.eliteGamesSortScore', 'ASC')
+            ->addOrderBy('athlete.displayName', 'ASC')
+            ->setMaxResults($limit);
+
+        if ($externalIds !== []) {
+            $queryBuilder
+                ->andWhere('athlete.externalId IN (:externalIds)')
+                ->setParameter('externalIds', $externalIds);
+        } elseif (!$force) {
+            $queryBuilder->andWhere('athlete.avatarUrl IS NULL');
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+
+    private function fetchAvatarUrl(Athlete $athlete): ?string
+    {
+        $profileUrl = $athlete->getSourceUrl() ?: sprintf('https://games.crossfit.com/athlete/%s', $athlete->getExternalId());
+        return $this->photoFetcher->fetch($profileUrl);
+    }
+}

--- a/src/Services/Competition/CrossFitGamesProfilePhotoFetcher.php
+++ b/src/Services/Competition/CrossFitGamesProfilePhotoFetcher.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services\Competition;
+
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class CrossFitGamesProfilePhotoFetcher
+{
+    private const PROFILE_PICTURE_PATTERN = '~https://profilepicsbucket\.crossfit\.com/[^"\'<>\s)]+~i';
+
+    public function __construct(private readonly HttpClientInterface $httpClient)
+    {
+    }
+
+    public function fetch(string $profileUrl): ?string
+    {
+        try {
+            $html = $this->httpClient->request('GET', $profileUrl)->getContent();
+        } catch (TransportExceptionInterface $exception) {
+            throw new \RuntimeException('Could not fetch CrossFit Games profile.', previous: $exception);
+        }
+
+        return $this->extract($html);
+    }
+
+    private function extract(string $html): ?string
+    {
+        $contentVariants = [
+            $html,
+            html_entity_decode($html, ENT_QUOTES | ENT_HTML5),
+            rawurldecode($html),
+        ];
+
+        foreach ($contentVariants as $content) {
+            if (preg_match(self::PROFILE_PICTURE_PATTERN, $content, $matches) === 1) {
+                return rtrim($matches[0], '\\');
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/CrossFitGamesProfilePhotoFetcherTest.php
+++ b/tests/CrossFitGamesProfilePhotoFetcherTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Tests;
+
+use App\Services\Competition\CrossFitGamesProfilePhotoFetcher;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class CrossFitGamesProfilePhotoFetcherTest extends TestCase
+{
+    public function testFetchesPhotoFromProfileHtml(): void
+    {
+        $fetcher = new CrossFitGamesProfilePhotoFetcher(new MockHttpClient([
+            new MockResponse('<img src="https://profilepicsbucket.crossfit.com/767cc-P975774_3-184.jpg" />'),
+        ]));
+
+        self::assertSame(
+            'https://profilepicsbucket.crossfit.com/767cc-P975774_3-184.jpg',
+            $fetcher->fetch('https://games.crossfit.com/athlete/975774'),
+        );
+    }
+
+    public function testFetchesPhotoFromUrlEncodedProfileHtml(): void
+    {
+        $fetcher = new CrossFitGamesProfilePhotoFetcher(new MockHttpClient([
+            new MockResponse('{"avatar":"https%3A%2F%2Fprofilepicsbucket.crossfit.com%2Ff1d92-P163097_5-184.jpg"}'),
+        ]));
+
+        self::assertSame(
+            'https://profilepicsbucket.crossfit.com/f1d92-P163097_5-184.jpg',
+            $fetcher->fetch('https://games.crossfit.com/athlete/163097'),
+        );
+    }
+
+    public function testReturnsNullWhenNoPhotoIsPresent(): void
+    {
+        $fetcher = new CrossFitGamesProfilePhotoFetcher(new MockHttpClient([
+            new MockResponse('<html>No profile photo here.</html>'),
+        ]));
+
+        self::assertNull($fetcher->fetch('https://games.crossfit.com/athlete/unknown'));
+    }
+}


### PR DESCRIPTION
## Summary
- add a Symfony command to backfill missing CrossFit Games athlete photos directly from Games profile pages
- extract profile photo fetching into a small tested service
- support targeted runs with repeated --external-id, plus --limit, --force and --dry-run

## Tests
- php bin/phpunit --colors=always --filter CrossFitGamesProfilePhotoFetcherTest
- php -l src/Command/BackfillCrossFitGamesAthletePhotosCommand.php
- php -l src/Services/Competition/CrossFitGamesProfilePhotoFetcher.php
- php -l tests/CrossFitGamesProfilePhotoFetcherTest.php

Note: php bin/console list app:athletes --env=test --no-debug currently fails during console boot on the existing Doctrine ConvertMappingCommand service, before this command runs.