### PR TITLE
Add normalized athlete identity matching

### DIFF
--- a/migrations/Version20260516100000.php
+++ b/migrations/Version20260516100000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260516100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add accent-insensitive normalized athlete names.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE athlete ADD normalized_name VARCHAR(255) DEFAULT NULL');
+        $this->addSql(<<<'SQL'
+UPDATE athlete SET normalized_name = lower(regexp_replace(translate(display_name, 'ÀÁÂÃÄÅĀĂĄàáâãäåāăąÇĆĈĊČçćĉċčÐĎĐðďđÈÉÊËĒĔĖĘĚèéêëēĕėęěÌÍÎÏĨĪĬĮİìíîïĩīĭįıÑŃŅŇñńņňÒÓÔÕÖØŌŎŐòóôõöøōŏőÙÚÛÜŨŪŬŮŰŲùúûüũūŭůűųÝŸŶýÿŷŽŹŻžźż', 'AAAAAAAAAaaaaaaaaaCCCCCcccccDDDdddEEEEEEEEEeeeeeeeeeIIIIIIIIIiiiiiiiiiNNNNnnnnOOOOOOOOOoooooooooUUUUUUUUUUuuuuuuuuuuYYYyyyZZZzzz'), '[^a-z0-9]+', ' ', 'g'))
+SQL);
+        $this->addSql(<<<'SQL'
+UPDATE athlete SET normalized_name = btrim(regexp_replace(normalized_name, '\s+', ' ', 'g'))
+SQL);
+        $this->addSql('CREATE INDEX IDX_ATHLETE_NORMALIZED_NAME ON athlete (normalized_name)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_ATHLETE_NORMALIZED_NAME');
+        $this->addSql('ALTER TABLE athlete DROP normalized_name');
+    }
+}

--- a/src/Command/ImportCompetitionResultsCommand.php
+++ b/src/Command/ImportCompetitionResultsCommand.php
@@ -17,6 +17,7 @@ use App\Entity\Workout\Workout;
 use App\Entity\Workout\WorkoutOrigin;
 use App\Entity\Workout\WorkoutOriginName;
 use App\Entity\Workout\WorkoutType;
+use App\Services\Competition\AthleteNameNormalizer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -49,8 +50,10 @@ class ImportCompetitionResultsCommand extends Command
      */
     private array $competitionDivisions = [];
 
-    public function __construct(private readonly EntityManagerInterface $entityManager)
-    {
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly AthleteNameNormalizer $athleteNameNormalizer,
+    ) {
         parent::__construct();
     }
 
@@ -246,6 +249,7 @@ class ImportCompetitionResultsCommand extends Command
 
         $athlete
             ->setDisplayName($displayName)
+            ->setNormalizedName($this->athleteNameNormalizer->normalize($displayName))
             ->setFirstName($this->stringOrNull($row['firstName'] ?? null))
             ->setLastName($this->stringOrNull($row['lastName'] ?? null))
             ->setGender($this->stringOrNull($row['gender'] ?? null))

--- a/src/Controller/Competition/AthleteResultSummaryController.php
+++ b/src/Controller/Competition/AthleteResultSummaryController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Competition;
 use App\Entity\Competition\Athlete;
 use App\Entity\Competition\WorkoutResult;
 use App\Entity\Workout\Workout;
+use App\Services\Competition\AthleteNameNormalizer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -14,16 +15,20 @@ use Symfony\Component\Routing\Attribute\Route;
 final class AthleteResultSummaryController extends AbstractController
 {
     #[Route('/api/athletes/{id}/result-summary', name: 'api_athlete_result_summary', methods: ['GET'])]
-    public function __invoke(string $id, EntityManagerInterface $entityManager): JsonResponse
-    {
+    public function __invoke(
+        string $id,
+        EntityManagerInterface $entityManager,
+        AthleteNameNormalizer $athleteNameNormalizer,
+    ): JsonResponse {
         $athlete = $entityManager->getRepository(Athlete::class)->find($id);
 
         if (!$athlete instanceof Athlete) {
             throw new NotFoundHttpException('Athlete not found.');
         }
 
+        $normalizedName = $athlete->getNormalizedName() ?: $athleteNameNormalizer->normalize($athlete->getDisplayName());
         $relatedAthletes = $entityManager->getRepository(Athlete::class)->findBy([
-            'displayName' => $athlete->getDisplayName(),
+            'normalizedName' => $normalizedName,
         ]);
 
         $results = $entityManager->createQueryBuilder()

--- a/src/Entity/Competition/Athlete.php
+++ b/src/Entity/Competition/Athlete.php
@@ -16,6 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'athlete')]
+#[ORM\Index(name: 'IDX_ATHLETE_NORMALIZED_NAME', columns: ['normalized_name'])]
 #[ORM\UniqueConstraint(name: 'UNIQ_ATHLETE_SOURCE_EXTERNAL', columns: ['source_name', 'external_id'])]
 #[ApiResource(operations: [new Get(), new GetCollection()], order: [
     'eliteGamesSortScore' => 'ASC',

--- a/src/Entity/Competition/Athlete.php
+++ b/src/Entity/Competition/Athlete.php
@@ -23,6 +23,7 @@ use Symfony\Component\Uid\Uuid;
 ])]
 #[ApiFilter(SearchFilter::class, properties: [
     'displayName' => 'ipartial',
+    'normalizedName' => 'ipartial',
     'firstName' => 'ipartial',
     'lastName' => 'ipartial',
     'sourceName' => 'exact',
@@ -38,6 +39,9 @@ class Athlete
 
     #[ORM\Column(length: 255)]
     private string $displayName;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $normalizedName = null;
 
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $firstName = null;
@@ -87,6 +91,7 @@ class Athlete
     public function __construct(string $displayName, string $sourceName, string $externalId)
     {
         $this->displayName = $displayName;
+        $this->normalizedName = self::normalizeDisplayName($displayName);
         $this->sourceName = $sourceName;
         $this->externalId = $externalId;
         $this->createdAt = new \DateTimeImmutable();
@@ -108,6 +113,20 @@ class Athlete
     public function setDisplayName(string $displayName): self
     {
         $this->displayName = $displayName;
+        $this->normalizedName = self::normalizeDisplayName($displayName);
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getNormalizedName(): ?string
+    {
+        return $this->normalizedName;
+    }
+
+    public function setNormalizedName(?string $normalizedName): self
+    {
+        $this->normalizedName = $normalizedName;
         $this->touch();
 
         return $this;
@@ -277,5 +296,31 @@ class Athlete
         }
 
         $this->eliteGamesSortScore = max(0, 9999 - $this->eliteGamesSeason) * 10000 + $this->eliteGamesRank;
+    }
+
+    private static function normalizeDisplayName(string $name): string
+    {
+        $normalized = trim($name);
+        if ($normalized === '') {
+            return '';
+        }
+
+        if (function_exists('transliterator_transliterate')) {
+            $transliterated = transliterator_transliterate('Any-Latin; Latin-ASCII', $normalized);
+            if (is_string($transliterated)) {
+                $normalized = $transliterated;
+            }
+        } else {
+            $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $normalized);
+            if (is_string($transliterated)) {
+                $normalized = $transliterated;
+            }
+        }
+
+        $normalized = strtolower($normalized);
+        $normalized = str_replace(['-', '_'], ' ', $normalized);
+        $normalized = preg_replace('/[^a-z0-9]+/', ' ', $normalized) ?? $normalized;
+
+        return trim(preg_replace('/\s+/', ' ', $normalized) ?? $normalized);
     }
 }

--- a/src/Services/Competition/AthleteNameNormalizer.php
+++ b/src/Services/Competition/AthleteNameNormalizer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services\Competition;
+
+final class AthleteNameNormalizer
+{
+    public function normalize(string $name): string
+    {
+        $normalized = trim($name);
+        if ($normalized === '') {
+            return '';
+        }
+
+        if (function_exists('transliterator_transliterate')) {
+            $transliterated = transliterator_transliterate('Any-Latin; Latin-ASCII', $normalized);
+            if (is_string($transliterated)) {
+                $normalized = $transliterated;
+            }
+        } else {
+            $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $normalized);
+            if (is_string($transliterated)) {
+                $normalized = $transliterated;
+            }
+        }
+
+        $normalized = strtolower($normalized);
+        $normalized = str_replace(['-', '_'], ' ', $normalized);
+        $normalized = preg_replace('/[^a-z0-9]+/', ' ', $normalized) ?? $normalized;
+
+        return trim(preg_replace('/\s+/', ' ', $normalized) ?? $normalized);
+    }
+}

--- a/tests/AthleteNameNormalizerTest.php
+++ b/tests/AthleteNameNormalizerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Tests;
+
+use App\Services\Competition\AthleteNameNormalizer;
+use PHPUnit\Framework\TestCase;
+
+final class AthleteNameNormalizerTest extends TestCase
+{
+    public function testNormalizesNamesWithoutAccents(): void
+    {
+        $normalizer = new AthleteNameNormalizer();
+
+        self::assertSame('oceane garat', $normalizer->normalize('Océane Garat'));
+        self::assertSame('oceane garat', $normalizer->normalize('Oceane Garat'));
+        self::assertSame('tia clair toomey', $normalizer->normalize('Tia-Clair Toomey'));
+    }
+}

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -106,6 +106,27 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         self::assertSame('https://profilepicsbucket.crossfit.com/tia.jpg', $athletes[0]['avatarUrl']);
     }
 
+    public function testFrontendCanSearchAthletesWithAccentInsensitiveNormalizedNames(): void
+    {
+        $entityManager = $this->getEntityManager();
+        $entityManager->persist(new Athlete('Oceane Garat', 'crossfit_games', 'oceane-games'));
+        $entityManager->persist(new Athlete('Océane Garat', 'scoring_fit', 'oceane-scoring-fit'));
+        $entityManager->persist(new Athlete('Ocean Other', 'crossfit_games', 'ocean-other'));
+        $entityManager->flush();
+
+        $this->browser()->request('GET', '/api/athletes?normalizedName=oceane%20garat');
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $athletes = $payload['member'] ?? $payload['hydra:member'] ?? [];
+        $names = array_map(static fn (array $athlete): ?string => $athlete['displayName'] ?? null, $athletes);
+
+        self::assertContains('Oceane Garat', $names);
+        self::assertContains('Océane Garat', $names);
+        self::assertNotContains('Ocean Other', $names);
+    }
+
     public function testFrontendListsLatestEliteGamesAthletesFirst(): void
     {
         $entityManager = $this->getEntityManager();
@@ -259,19 +280,19 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         $entityManager = $this->getEntityManager();
         /** @var Workout $workout */
         $workout = $this->getReference(WorkoutData::WORKOUT_OPEN_17_5, Workout::class);
-        $gamesProfile = new Athlete('Sabrina Caron', 'crossfit_games', 'sabrina-games');
-        $cornerProfile = new Athlete('Sabrina Caron', 'competition_corner', 'sabrina-corner');
+        $gamesProfile = new Athlete('Oceane Garat', 'crossfit_games', 'oceane-games');
+        $cornerProfile = new Athlete('Océane Garat', 'competition_corner', 'oceane-corner');
         $otherAthlete = new Athlete('Other Athlete', 'crossfit_games', 'other-athlete');
         $competition = (new Competition('2019 Games', 'crossfit_games', 'games-2019'))
             ->setSeason(2019);
         $event = (new CompetitionEvent($competition, 'Event 1', 'crossfit_games', 'games-2019-event-1'))
             ->setWorkout($workout);
         $division = new CompetitionDivision($competition, 'Women', 'crossfit_games', 'games-2019-women');
-        $gamesResult = (new WorkoutResult($gamesProfile, $event, new Score(ScoreTypeEnum::TIME, '8:21'), 'crossfit_games', 'sabrina-games-event-1'))
+        $gamesResult = (new WorkoutResult($gamesProfile, $event, new Score(ScoreTypeEnum::TIME, '8:21'), 'crossfit_games', 'oceane-games-event-1'))
             ->setCompetitionDivision($division)
             ->setRank(12)
             ->setFieldSize(40);
-        $cornerResult = (new WorkoutResult($cornerProfile, $event, new Score(ScoreTypeEnum::REPS, '127'), 'competition_corner', 'sabrina-corner-event-1'))
+        $cornerResult = (new WorkoutResult($cornerProfile, $event, new Score(ScoreTypeEnum::REPS, '127'), 'competition_corner', 'oceane-corner-event-1'))
             ->setCompetitionDivision($division)
             ->setRank(2)
             ->setFieldSize(18);


### PR DESCRIPTION
## Summary
- add accent-insensitive normalizedName to athletes with migration/backfill
- populate normalized names during imports and entity creation
- use normalized names for compact athlete result aggregation so Oceane/Océane profiles share result pages
- expose normalizedName as an API search filter

## Tests
- php bin/phpunit --colors=always --filter AthleteNameNormalizerTest
- composer cs:check

## Not run locally
- DB-backed PHPUnit filters: local Docker daemon was not reachable from the terminal, so CI should validate these.