### PR TITLE
Clarify missing athlete analysis API key

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    env(CHAT_GPT_API_KEY): ''
     maxNumberOfRounds: 10
 
 services:

--- a/src/Services/Competition/AthletePublicAnalysisGenerator.php
+++ b/src/Services/Competition/AthletePublicAnalysisGenerator.php
@@ -209,7 +209,7 @@ final readonly class AthletePublicAnalysisGenerator
      */
     private function requestAnalysis(Athlete $athlete, array $input): array
     {
-        if ($this->chatGPTApiKey === '') {
+        if (trim($this->chatGPTApiKey) === '') {
             throw new \RuntimeException('CHAT_GPT_API_KEY is required to generate athlete public analyses.');
         }
 

--- a/tests/AthletePublicAnalysisGeneratorTest.php
+++ b/tests/AthletePublicAnalysisGeneratorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Competition\Athlete;
+use App\Services\Competition\AthletePublicAnalysisGenerator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+final class AthletePublicAnalysisGeneratorTest extends TestCase
+{
+    public function testBlankApiKeyFailsWithExplicitConfigurationError(): void
+    {
+        $generator = new AthletePublicAnalysisGenerator(
+            $this->createMock(EntityManagerInterface::class),
+            new MockHttpClient(),
+            '   ',
+        );
+
+        $method = new \ReflectionMethod($generator, 'requestAnalysis');
+        $method->setAccessible(true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('CHAT_GPT_API_KEY is required to generate athlete public analyses.');
+
+        $method->invoke($generator, new Athlete('Mathew Fraser', 'crossfit_games', 'mat-fraser'), [
+            [
+                'competition' => 'CrossFit Games',
+                'season' => 2016,
+                'event' => 'Final',
+                'rank' => 1,
+                'score' => '1st',
+                'workout' => ['name' => 'Final', 'flow' => 'For time'],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a safe default for CHAT_GPT_API_KEY so missing prod config reaches the public analysis controller
- Treat whitespace-only API keys as missing
- Cover the explicit configuration error with a targeted unit test

## Tests
- php -l src/Services/Competition/AthletePublicAnalysisGenerator.php
- php -l tests/AthletePublicAnalysisGeneratorTest.php
- composer cs:check
- php bin/phpunit --colors=always --filter AthletePublicAnalysisGeneratorTest

Note: php bin/phpunit --colors=always --filter WorkoutApiWorkflowTest could not run locally because PostgreSQL is not accepting connections on 127.0.0.1:5432.