### PR TITLE
Configure athlete analysis OpenAI model

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,6 +5,7 @@
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
     env(CHAT_GPT_API_KEY): ''
+    env(OPENAI_MODEL): 'gpt-5.4-mini'
     maxNumberOfRounds: 10
 
 services:
@@ -39,6 +40,7 @@ services:
     App\Services\Competition\AthletePublicAnalysisGenerator:
         arguments:
             $chatGPTApiKey: '%env(CHAT_GPT_API_KEY)%'
+            $openAiModel: '%env(OPENAI_MODEL)%'
 
     App\Services\Workout\MovementDifficultyServiceInterface:
         class: App\Services\Workout\MovementDifficultyService


### PR DESCRIPTION
## Summary
- Add an OPENAI_MODEL env default for Symfony
- Inject OPENAI_MODEL into the athlete public analysis generator
- Keep production model selection configurable through .env.local

## Tests
- php -l src/Services/Competition/AthletePublicAnalysisGenerator.php
- composer cs:check
- php bin/phpunit --colors=always --filter AthletePublicAnalysisGeneratorTest