### PR TITLE
Throttle profile analysis reloads

### DIFF
--- a/src/Controller/Profile/MeController.php
+++ b/src/Controller/Profile/MeController.php
@@ -25,6 +25,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted('ROLE_USER')]
 class MeController extends AbstractController
 {
+    private const ANALYSIS_REQUEST_COOLDOWN = 'PT5M';
+
     private const VALID_LINK_TYPES = [
         UserAthleteProfile::LINK_SELF,
         UserAthleteProfile::LINK_COACHED,
@@ -164,6 +166,16 @@ class MeController extends AbstractController
     public function createPerformanceAnalysisRequest(Request $request): JsonResponse
     {
         $user = $this->currentUser();
+        $latestRequest = $this->latestAnalysisRequest($user);
+        $nextAvailableAt = $latestRequest?->getCreatedAt()->add(new \DateInterval(self::ANALYSIS_REQUEST_COOLDOWN));
+        if ($nextAvailableAt !== null && $nextAvailableAt > new \DateTimeImmutable()) {
+            return $this->json([
+                'error' => 'A recent performance analysis request already exists.',
+                'latestAnalysisRequest' => $this->serializeAnalysisRequest($latestRequest),
+                'nextAvailableAt' => $this->date($nextAvailableAt),
+            ], Response::HTTP_TOO_MANY_REQUESTS);
+        }
+
         $profile = $this->getLatestPerformanceProfile($user);
         if ($profile === null) {
             return $this->json(['error' => 'Performance profile is required.'], Response::HTTP_BAD_REQUEST);
@@ -486,6 +498,17 @@ class MeController extends AbstractController
         );
 
         return $profile;
+    }
+
+    private function latestAnalysisRequest(User $user): ?PerformanceAnalysisRequest
+    {
+        /** @var PerformanceAnalysisRequest|null $request */
+        $request = $this->entityManager->getRepository(PerformanceAnalysisRequest::class)->findOneBy(
+            ['user' => $user],
+            ['createdAt' => 'DESC']
+        );
+
+        return $request;
     }
 
     /**

--- a/tests/PrivateUserProfileApiTest.php
+++ b/tests/PrivateUserProfileApiTest.php
@@ -197,6 +197,36 @@ class PrivateUserProfileApiTest extends AbstractIntegrationTest
         self::assertCount(1, $requestsPayload['programmingRequests']);
     }
 
+    public function testUserCannotCreateAnotherAnalysisRequestWithinFiveMinutes(): void
+    {
+        [$token, $user] = $this->createAuthenticatedUser('analysis-cooldown@example.com', 'analysis-cooldown-token');
+        $performanceProfile = new UserPerformanceProfile($user);
+        (new UserPerformanceMetric($performanceProfile, PerformanceMetricKeyEnum::BACK_SQUAT_1RM))->setNumericValue(150);
+
+        $this->getEntityManager()->persist($performanceProfile);
+        $this->getEntityManager()->flush();
+
+        $this->jsonRequest('POST', '/api/me/performance-analysis-requests', [
+            'parameters' => [
+                'goal' => 'first pass',
+            ],
+        ], $token);
+
+        self::assertResponseStatusCodeSame(201);
+
+        $this->jsonRequest('POST', '/api/me/performance-analysis-requests', [
+            'parameters' => [
+                'goal' => 'too soon',
+            ],
+        ], $token);
+
+        self::assertResponseStatusCodeSame(429);
+        $payload = $this->jsonResponse();
+        self::assertSame('A recent performance analysis request already exists.', $payload['error']);
+        self::assertSame('first pass', $payload['latestAnalysisRequest']['parameters']['goal']);
+        self::assertArrayHasKey('nextAvailableAt', $payload);
+    }
+
     /**
      * @return array{0: string, 1: User}
      */


### PR DESCRIPTION
## Summary
- allow member performance analysis requests only when no previous request exists or the latest is older than 5 minutes
- return a 429 response with the latest request and next available timestamp when reload is too soon
- cover the cooldown with a profile API test

## Tests
- php -l src/Controller/Profile/MeController.php
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter PrivateUserProfileApiTest *(fails locally: PostgreSQL test database connection refused)*