### PR TITLE
Import competition logo URLs

### DIFF
--- a/migrations/Version20260517100000.php
+++ b/migrations/Version20260517100000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260517100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add optional competition logo URL.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE competition ADD logo_url VARCHAR(2048) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE competition DROP logo_url');
+    }
+}

--- a/src/Command/ImportCompetitionResultsCommand.php
+++ b/src/Command/ImportCompetitionResultsCommand.php
@@ -285,7 +285,8 @@ class ImportCompetitionResultsCommand extends Command
         $competition
             ->setName($name)
             ->setSeason($this->intOrNull($row['season'] ?? null))
-            ->setSourceUrl($sourceUrl);
+            ->setSourceUrl($sourceUrl)
+            ->setLogoUrl($this->stringOrNull($row['logoUrl'] ?? null));
 
         return $status;
     }

--- a/src/Controller/Competition/AthleteResultSummaryController.php
+++ b/src/Controller/Competition/AthleteResultSummaryController.php
@@ -106,6 +106,7 @@ final class AthleteResultSummaryController extends AbstractController
                 'sourceName' => $competition->getSourceName(),
                 'externalId' => $competition->getExternalId(),
                 'sourceUrl' => $competition->getSourceUrl(),
+                'logoUrl' => $competition->getLogoUrl(),
             ],
             'competitionDivisionDetails' => $division ? [
                 '@id' => '/api/competition_divisions/'.$division->getId(),

--- a/src/Entity/Competition/Competition.php
+++ b/src/Entity/Competition/Competition.php
@@ -37,6 +37,9 @@ class Competition
     #[ORM\Column(length: 2048, nullable: true)]
     private ?string $sourceUrl = null;
 
+    #[ORM\Column(length: 2048, nullable: true)]
+    private ?string $logoUrl = null;
+
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
 
@@ -105,6 +108,19 @@ class Competition
     public function setSourceUrl(?string $sourceUrl): self
     {
         $this->sourceUrl = $sourceUrl;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getLogoUrl(): ?string
+    {
+        return $this->logoUrl;
+    }
+
+    public function setLogoUrl(?string $logoUrl): self
+    {
+        $this->logoUrl = $logoUrl;
         $this->touch();
 
         return $this;

--- a/src/Entity/Workout/Workout.php
+++ b/src/Entity/Workout/Workout.php
@@ -244,6 +244,7 @@ class Workout
      * @return list<array{
      *     competitionName: string,
      *     competitionSeason: int|null,
+     *     competitionLogoUrl: string|null,
      *     eventName: string,
      *     eventOrder: int|null,
      *     sourceName: string,
@@ -273,6 +274,7 @@ class Workout
             $context = [
                 'competitionName' => $competition->getName(),
                 'competitionSeason' => $competition->getSeason(),
+                'competitionLogoUrl' => $competition->getLogoUrl(),
                 'eventName' => $event->getName(),
                 'eventOrder' => $event->getEventOrder(),
                 'sourceName' => $event->getSourceName(),

--- a/tests/ImportCompetitionResultsCommandTest.php
+++ b/tests/ImportCompetitionResultsCommandTest.php
@@ -93,6 +93,7 @@ class ImportCompetitionResultsCommandTest extends AbstractIntegrationTest
                     'source' => ['externalId' => 'games-2024'],
                     'name' => 'CrossFit Games',
                     'season' => 2024,
+                    'logoUrl' => 'https://example.test/crossfit-games.png',
                 ],
             ],
             'events' => [
@@ -152,6 +153,14 @@ class ImportCompetitionResultsCommandTest extends AbstractIntegrationTest
             self::assertSame('https://profilepicsbucket.crossfit.com/athlete-one.jpg', $athlete->getAvatarUrl());
             self::assertSame(1, $athlete->getEliteGamesRank());
             self::assertSame(2024, $athlete->getEliteGamesSeason());
+
+            /** @var Competition|null $competition */
+            $competition = $this->getRepository(Competition::class)->findOneBy([
+                'sourceName' => 'crossfit_games',
+                'externalId' => 'games-2024',
+            ]);
+            self::assertNotNull($competition);
+            self::assertSame('https://example.test/crossfit-games.png', $competition->getLogoUrl());
         } finally {
             @unlink($file);
         }

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -63,6 +63,7 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
             [
                 'competitionName' => 'CrossFit Games Open',
                 'competitionSeason' => 2017,
+                'competitionLogoUrl' => null,
                 'eventName' => 'Open 17.5',
                 'eventOrder' => 5,
                 'sourceName' => 'crossfit_games',
@@ -323,6 +324,7 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         self::assertSame(2, $payload['totalItems']);
         self::assertCount(2, $payload['member']);
         self::assertSame('2019 Games', $payload['member'][0]['competitionDetails']['name']);
+        self::assertArrayHasKey('logoUrl', $payload['member'][0]['competitionDetails']);
         self::assertSame('Event 1', $payload['member'][0]['eventDetails']['name']);
         self::assertSame('Open 17.5', $payload['member'][0]['workoutDetails']['name']);
         self::assertArrayHasKey('scoreDetails', $payload['member'][0]);


### PR DESCRIPTION
## Summary
- add an optional logoUrl field to competitions
- import competition logoUrl values from the Symfony payload
- expose logoUrl in athlete result competitionDetails

## Tests
- php -l src/Entity/Competition/Competition.php
- php -l src/Command/ImportCompetitionResultsCommand.php
- php -l src/Controller/Competition/AthleteResultSummaryController.php
- php -l migrations/Version20260517100000.php

## Notes
- Targeted PHPUnit could not run locally because the Docker daemon/PostgreSQL test database was not running.