### PR TITLE
Backfill competition logos

### DIFF
--- a/src/Command/BackfillCompetitionLogosCommand.php
+++ b/src/Command/BackfillCompetitionLogosCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Competition\Competition;
+use App\Services\Competition\CompetitionLogoFetcher;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:competitions:backfill-logos',
+    description: 'Backfill missing Competition Corner and Scoring.fit competition logos.',
+)]
+final class BackfillCompetitionLogosCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly CompetitionLogoFetcher $logoFetcher,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum competitions to inspect.', '50')
+            ->addOption('source', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Limit to a source name. Defaults to competition_corner and scoring_fit.')
+            ->addOption('external-id', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Only inspect one competition external id. Can be passed multiple times.')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Refresh logos even when logo_url is already present.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Fetch logos and print what would change without writing to the database.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $limit = max(1, (int) $input->getOption('limit'));
+        $sources = array_values(array_filter(array_map('strval', (array) $input->getOption('source'))));
+        $externalIds = array_values(array_filter(array_map('strval', (array) $input->getOption('external-id'))));
+        $force = (bool) $input->getOption('force');
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        if ($sources === []) {
+            $sources = ['competition_corner', 'scoring_fit'];
+        }
+
+        $inspected = 0;
+        $updated = 0;
+        $missing = 0;
+        $failed = 0;
+
+        foreach ($this->findCompetitions($limit, $sources, $externalIds, $force) as $competition) {
+            ++$inspected;
+
+            try {
+                $logoUrl = $this->logoFetcher->fetch($competition);
+            } catch (\Throwable $exception) {
+                ++$failed;
+                $io->warning(sprintf('%s (%s/%s): %s', $competition->getName(), $competition->getSourceName(), $competition->getExternalId(), $exception->getMessage()));
+                continue;
+            }
+
+            if ($logoUrl === null) {
+                ++$missing;
+                $io->writeln(sprintf('Missing %s (%s/%s)', $competition->getName(), $competition->getSourceName(), $competition->getExternalId()));
+                continue;
+            }
+
+            $io->writeln(sprintf('Logo %s (%s/%s): %s', $competition->getName(), $competition->getSourceName(), $competition->getExternalId(), $logoUrl));
+            if (!$dryRun) {
+                $competition->setLogoUrl($logoUrl);
+                ++$updated;
+            }
+        }
+
+        if ($updated > 0 && !$dryRun) {
+            $this->entityManager->flush();
+        }
+
+        $io->table(
+            ['inspected', 'updated', 'missing', 'failed'],
+            [[$inspected, $updated, $missing, $failed]],
+        );
+
+        return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * @param list<string> $sources
+     * @param list<string> $externalIds
+     *
+     * @return list<Competition>
+     */
+    private function findCompetitions(int $limit, array $sources, array $externalIds, bool $force): array
+    {
+        $queryBuilder = $this->entityManager->getRepository(Competition::class)->createQueryBuilder('competition')
+            ->andWhere('competition.sourceName IN (:sources)')
+            ->setParameter('sources', $sources)
+            ->orderBy('competition.sourceName', 'ASC')
+            ->addOrderBy('competition.externalId', 'ASC')
+            ->setMaxResults($limit);
+
+        if ($externalIds !== []) {
+            $queryBuilder
+                ->andWhere('competition.externalId IN (:externalIds)')
+                ->setParameter('externalIds', $externalIds);
+        } elseif (!$force) {
+            $queryBuilder->andWhere('competition.logoUrl IS NULL');
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+}

--- a/src/Services/Competition/CompetitionLogoFetcher.php
+++ b/src/Services/Competition/CompetitionLogoFetcher.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Services\Competition;
+
+use App\Entity\Competition\Competition;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class CompetitionLogoFetcher
+{
+    public function __construct(private readonly HttpClientInterface $httpClient)
+    {
+    }
+
+    public function fetch(Competition $competition): ?string
+    {
+        foreach ($this->candidateUrls($competition) as $url) {
+            try {
+                $html = $this->httpClient->request('GET', $url)->getContent();
+            } catch (TransportExceptionInterface $exception) {
+                throw new \RuntimeException(sprintf('Could not fetch competition logo page %s.', $url), previous: $exception);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            $logoUrl = match ($competition->getSourceName()) {
+                'competition_corner' => $this->extractCompetitionCornerLogo($html, $url),
+                'scoring_fit' => $this->extractScoringFitLogo($html, $url),
+                default => null,
+            };
+
+            if ($logoUrl !== null) {
+                return $logoUrl;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function candidateUrls(Competition $competition): array
+    {
+        $externalId = $competition->getExternalId();
+        $sourceUrl = $competition->getSourceUrl();
+
+        $urls = match ($competition->getSourceName()) {
+            'competition_corner' => [
+                sprintf('https://competitioncorner.net/events/%s/details', $externalId),
+                $sourceUrl,
+            ],
+            'scoring_fit' => [
+                sprintf('https://scoring.fit/%s', $externalId),
+                $sourceUrl ? str_replace('https://scoring.fit/leaderboard/', 'https://scoring.fit/', $sourceUrl) : null,
+                $sourceUrl,
+            ],
+            default => [],
+        };
+
+        return array_values(array_unique(array_filter($urls, static fn (?string $url): bool => $url !== null && $url !== '')));
+    }
+
+    private function extractCompetitionCornerLogo(string $html, string $sourceUrl): ?string
+    {
+        if (preg_match('~<img\b(?=[^>]*\bcustom-logo\b)[^>]*\bsrc=["\']([^"\']+)["\']~i', $html, $matches) !== 1) {
+            return null;
+        }
+
+        return $this->absoluteUrl(html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5), $sourceUrl);
+    }
+
+    private function extractScoringFitLogo(string $html, string $sourceUrl): ?string
+    {
+        if (preg_match('~<(?:div|section)\b(?=[^>]*\b(?:hero-image-logo|logo-image-background)\b)[^>]*>.*?<img\b[^>]*\bsrc=["\']([^"\']+)["\']~is', $html, $matches) !== 1) {
+            return null;
+        }
+
+        return $this->absoluteUrl(html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5), $sourceUrl);
+    }
+
+    private function absoluteUrl(string $url, string $sourceUrl): string
+    {
+        if (preg_match('~^https?://~i', $url) === 1) {
+            return $url;
+        }
+        if (str_starts_with($url, '//')) {
+            return 'https:'.$url;
+        }
+
+        $sourceParts = parse_url($sourceUrl);
+        $scheme = isset($sourceParts['scheme']) ? $sourceParts['scheme'].'://' : 'https://';
+        $host = $sourceParts['host'] ?? '';
+        if (str_starts_with($url, '/')) {
+            return $scheme.$host.$url;
+        }
+
+        $path = $sourceParts['path'] ?? '/';
+        $basePath = rtrim(str_replace('\\', '/', dirname($path)), '/');
+
+        return $scheme.$host.$basePath.'/'.$url;
+    }
+}

--- a/tests/CompetitionLogoFetcherTest.php
+++ b/tests/CompetitionLogoFetcherTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Competition\Competition;
+use App\Services\Competition\CompetitionLogoFetcher;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class CompetitionLogoFetcherTest extends TestCase
+{
+    public function testFetchesCompetitionCornerLogo(): void
+    {
+        $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('<img alt="" class="custom-logo mt-0" src="https://competitioncorner.net/file.aspx/mainFilesystem?General%2f6g7sow2b3.jpg&amp;thumbnail=1080,1080">'),
+        ]));
+        $competition = new Competition('French Throwdown', 'competition_corner', '20465');
+
+        self::assertSame(
+            'https://competitioncorner.net/file.aspx/mainFilesystem?General%2f6g7sow2b3.jpg&thumbnail=1080,1080',
+            $fetcher->fetch($competition),
+        );
+    }
+
+    public function testFetchesScoringFitLogo(): void
+    {
+        $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('<div class="hero-image-logo"><img src="https://scoring-images.s3.eu-west-3.amazonaws.com/events/logo.png?1779003354922" alt="logo"></div>'),
+        ]));
+        $competition = new Competition('Scoring Event', 'scoring_fit', '3051');
+
+        self::assertSame(
+            'https://scoring-images.s3.eu-west-3.amazonaws.com/events/logo.png?1779003354922',
+            $fetcher->fetch($competition),
+        );
+    }
+
+    public function testReturnsNullWhenNoLogoIsPresent(): void
+    {
+        $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('<html>No logo here.</html>'),
+        ]));
+        $competition = new Competition('Scoring Event', 'scoring_fit', '3051');
+
+        self::assertNull($fetcher->fetch($competition));
+    }
+}


### PR DESCRIPTION
## Summary
- add a Symfony command to backfill missing Competition Corner and Scoring.fit competition logos
- fetch Competition Corner logos from event details pages
- fetch Scoring.fit logos from public event pages

## Tests
- php -l src/Services/Competition/CompetitionLogoFetcher.php
- php -l src/Command/BackfillCompetitionLogosCommand.php
- php -l tests/CompetitionLogoFetcherTest.php
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter CompetitionLogoFetcherTest
- php bin/console list app:competitions --env=test