### PR TITLE
Read Competition Corner logos from event payloads

### DIFF
--- a/src/Services/Competition/CompetitionLogoFetcher.php
+++ b/src/Services/Competition/CompetitionLogoFetcher.php
@@ -64,10 +64,57 @@ final class CompetitionLogoFetcher
     private function extractCompetitionCornerLogo(string $html, string $sourceUrl): ?string
     {
         if (preg_match('~<img\b(?=[^>]*\bcustom-logo\b)[^>]*\bsrc=["\']([^"\']+)["\']~i', $html, $matches) !== 1) {
+            foreach ($this->competitionCornerLogoCandidates($html) as $candidate) {
+                return $this->competitionCornerImageUrl($candidate, $sourceUrl);
+            }
+
             return null;
         }
 
-        return $this->absoluteUrl(html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5), $sourceUrl);
+        return $this->competitionCornerImageUrl(html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5), $sourceUrl);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function competitionCornerLogoCandidates(string $html): array
+    {
+        $decoded = html_entity_decode($html, ENT_QUOTES | ENT_HTML5);
+        $patterns = [
+            '~"eventPageLogoImage"\s*:\s*"([^"]+)"~',
+            '~"logo"\s*:\s*"([^"]+)"~',
+            '~<meta\s+property=["\']og:image["\']\s+content=["\']([^"\']+)["\']~i',
+            '~<meta\s+name=["\']twitter:image["\']\s+content=["\']([^"\']+)["\']~i',
+        ];
+
+        $candidates = [];
+        foreach ($patterns as $pattern) {
+            if (preg_match_all($pattern, $decoded, $matches) !== false) {
+                foreach ($matches[1] as $match) {
+                    $candidate = trim($match);
+                    if ($candidate !== '') {
+                        $candidates[] = $candidate;
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($candidates));
+    }
+
+    private function competitionCornerImageUrl(string $url, string $sourceUrl): string
+    {
+        if (preg_match('~^(?:https?:)?//|^/~i', $url) === 1 || str_starts_with($url, 'file.aspx')) {
+            return $this->absoluteUrl($url, $sourceUrl);
+        }
+
+        if (preg_match('~^[A-Za-z]+/.+\.(?:jpe?g|png|gif|webp)$~i', $url) === 1) {
+            $path = str_replace('%2F', '%2f', rawurlencode($url));
+
+            return sprintf('https://competitioncorner.net/file.aspx/mainFilesystem?%s&thumbnail=1080,1080', $path);
+        }
+
+        return $this->absoluteUrl($url, $sourceUrl);
     }
 
     private function extractScoringFitLogo(string $html, string $sourceUrl): ?string

--- a/tests/CompetitionLogoFetcherTest.php
+++ b/tests/CompetitionLogoFetcherTest.php
@@ -23,6 +23,32 @@ final class CompetitionLogoFetcherTest extends TestCase
         );
     }
 
+    public function testFetchesCompetitionCornerLogoFromEncodedEventPayload(): void
+    {
+        $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('<app-root visual="{&quot;logo&quot;:&quot;https://competitioncorner.net/file.aspx/mainFilesystem?Events%2fck56xibbz.jpg&amp;thumbnail=1080,1080&quot;}" eventdata="{&quot;event&quot;:{&quot;eventPageLogoImage&quot;:&quot;General/6g7sow2b3.jpg&quot;}}"></app-root>'),
+        ]));
+        $competition = new Competition('French Throwdown', 'competition_corner', '20465');
+
+        self::assertSame(
+            'https://competitioncorner.net/file.aspx/mainFilesystem?General%2f6g7sow2b3.jpg&thumbnail=1080,1080',
+            $fetcher->fetch($competition),
+        );
+    }
+
+    public function testFetchesCompetitionCornerLogoFromVisualPayloadWhenNoEventPageLogoExists(): void
+    {
+        $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('<app-root visual="{&quot;logo&quot;:&quot;https://competitioncorner.net/file.aspx/mainFilesystem?Events%2f455a18m3n.png&amp;thumbnail=1080,1080&quot;}"></app-root>'),
+        ]));
+        $competition = new Competition('Wodapalooza', 'competition_corner', '19193');
+
+        self::assertSame(
+            'https://competitioncorner.net/file.aspx/mainFilesystem?Events%2f455a18m3n.png&thumbnail=1080,1080',
+            $fetcher->fetch($competition),
+        );
+    }
+
     public function testFetchesScoringFitLogo(): void
     {
         $fetcher = new CompetitionLogoFetcher(new MockHttpClient([


### PR DESCRIPTION
## Summary
- parse Competition Corner logos embedded in app-root event payloads
- prefer eventPageLogoImage when present, then visual logo and social image fallbacks
- normalize Competition Corner VFS paths such as General/foo.png to file.aspx URLs

## Tests
- php -l src/Services/Competition/CompetitionLogoFetcher.php
- php -l tests/CompetitionLogoFetcherTest.php
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter CompetitionLogoFetcherTest