### PR TITLE
Fix Scoring.fit logo backfill

### DIFF
--- a/src/Command/BackfillCompetitionLogosCommand.php
+++ b/src/Command/BackfillCompetitionLogosCommand.php
@@ -101,7 +101,7 @@ final class BackfillCompetitionLogosCommand extends Command
             ->andWhere('competition.sourceName IN (:sources)')
             ->setParameter('sources', $sources)
             ->orderBy('competition.sourceName', 'ASC')
-            ->addOrderBy('competition.externalId', 'ASC')
+            ->addOrderBy('competition.externalId', 'DESC')
             ->setMaxResults($limit);
 
         if ($externalIds !== []) {

--- a/src/Services/Competition/CompetitionLogoFetcher.php
+++ b/src/Services/Competition/CompetitionLogoFetcher.php
@@ -14,6 +14,13 @@ final class CompetitionLogoFetcher
 
     public function fetch(Competition $competition): ?string
     {
+        if ($competition->getSourceName() === 'scoring_fit') {
+            $logoUrl = $this->fetchScoringFitStoredLogo($competition->getExternalId());
+            if ($logoUrl !== null) {
+                return $logoUrl;
+            }
+        }
+
         foreach ($this->candidateUrls($competition) as $url) {
             try {
                 $html = $this->httpClient->request('GET', $url)->getContent();
@@ -124,6 +131,29 @@ final class CompetitionLogoFetcher
         }
 
         return $this->absoluteUrl(html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5), $sourceUrl);
+    }
+
+    private function fetchScoringFitStoredLogo(string $externalId): ?string
+    {
+        if (preg_match('~^[a-f0-9]{24}$~i', $externalId) !== 1) {
+            return null;
+        }
+
+        $logoUrl = sprintf('https://scoring-images.s3.eu-west-3.amazonaws.com/events/%s/logo.png', $externalId);
+
+        try {
+            $statusCode = $this->httpClient->request('HEAD', $logoUrl)->getStatusCode();
+        } catch (TransportExceptionInterface $exception) {
+            throw new \RuntimeException(sprintf('Could not fetch Scoring.fit logo %s.', $logoUrl), previous: $exception);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if ($statusCode >= 200 && $statusCode < 300) {
+            return $logoUrl;
+        }
+
+        return null;
     }
 
     private function absoluteUrl(string $url, string $sourceUrl): string

--- a/tests/CompetitionLogoFetcherTest.php
+++ b/tests/CompetitionLogoFetcherTest.php
@@ -52,9 +52,10 @@ final class CompetitionLogoFetcherTest extends TestCase
     public function testFetchesScoringFitLogo(): void
     {
         $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('', ['http_code' => 404]),
             new MockResponse('<div class="hero-image-logo"><img src="https://scoring-images.s3.eu-west-3.amazonaws.com/events/logo.png?1779003354922" alt="logo"></div>'),
         ]));
-        $competition = new Competition('Scoring Event', 'scoring_fit', '3051');
+        $competition = new Competition('Scoring Event', 'scoring_fit', '6011528bc482ba00041018ad');
 
         self::assertSame(
             'https://scoring-images.s3.eu-west-3.amazonaws.com/events/logo.png?1779003354922',
@@ -62,9 +63,23 @@ final class CompetitionLogoFetcherTest extends TestCase
         );
     }
 
+    public function testFetchesScoringFitStoredLogoFromExternalId(): void
+    {
+        $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('', ['http_code' => 200]),
+        ]));
+        $competition = new Competition('Scoring Event', 'scoring_fit', '69a8200cf6c7b70033e2377e');
+
+        self::assertSame(
+            'https://scoring-images.s3.eu-west-3.amazonaws.com/events/69a8200cf6c7b70033e2377e/logo.png',
+            $fetcher->fetch($competition),
+        );
+    }
+
     public function testReturnsNullWhenNoLogoIsPresent(): void
     {
         $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('', ['http_code' => 404]),
             new MockResponse('<html>No logo here.</html>'),
         ]));
         $competition = new Competition('Scoring Event', 'scoring_fit', '3051');


### PR DESCRIPTION
## Summary
- check Scoring.fit's stored S3 logo path before falling back to page parsing
- inspect newest competitions first so old missing logos do not block newer events
- cover the stored-logo path in the logo fetcher tests

## Tests
- php -d memory_limit=1G bin/phpunit --colors=always --filter CompetitionLogoFetcherTest