### PR TITLE
Read Scoring.fit icon links for logos

### DIFF
--- a/src/Services/Competition/CompetitionLogoFetcher.php
+++ b/src/Services/Competition/CompetitionLogoFetcher.php
@@ -15,6 +15,11 @@ final class CompetitionLogoFetcher
     public function fetch(Competition $competition): ?string
     {
         if ($competition->getSourceName() === 'scoring_fit') {
+            $logoUrl = $this->fetchScoringFitApiLogo($competition->getExternalId());
+            if ($logoUrl !== null) {
+                return $logoUrl;
+            }
+
             $logoUrl = $this->fetchScoringFitStoredLogo($competition->getExternalId());
             if ($logoUrl !== null) {
                 return $logoUrl;
@@ -154,6 +159,40 @@ final class CompetitionLogoFetcher
         }
 
         return null;
+    }
+
+    private function fetchScoringFitApiLogo(string $externalId): ?string
+    {
+        $apiUrl = sprintf('https://scoring-fit-prod-7a29180d25c8.herokuapp.com/api/leaderboard/competition/%s', rawurlencode($externalId));
+
+        try {
+            $response = $this->httpClient->request('GET', $apiUrl);
+            if ($response->getStatusCode() < 200 || $response->getStatusCode() >= 300) {
+                return null;
+            }
+
+            $payload = json_decode($response->getContent(false), true, flags: JSON_THROW_ON_ERROR);
+        } catch (TransportExceptionInterface $exception) {
+            throw new \RuntimeException(sprintf('Could not fetch Scoring.fit competition API %s.', $apiUrl), previous: $exception);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (!is_array($payload)) {
+            return null;
+        }
+
+        $logoUrl = $payload['data']['competition']['iconLink'] ?? null;
+        if (!is_string($logoUrl)) {
+            return null;
+        }
+
+        $logoUrl = trim($logoUrl);
+        if ($logoUrl === '' || preg_match('~^https?://~i', $logoUrl) !== 1) {
+            return null;
+        }
+
+        return $logoUrl;
     }
 
     private function absoluteUrl(string $url, string $sourceUrl): string

--- a/tests/CompetitionLogoFetcherTest.php
+++ b/tests/CompetitionLogoFetcherTest.php
@@ -53,6 +53,7 @@ final class CompetitionLogoFetcherTest extends TestCase
     {
         $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
             new MockResponse('', ['http_code' => 404]),
+            new MockResponse('', ['http_code' => 404]),
             new MockResponse('<div class="hero-image-logo"><img src="https://scoring-images.s3.eu-west-3.amazonaws.com/events/logo.png?1779003354922" alt="logo"></div>'),
         ]));
         $competition = new Competition('Scoring Event', 'scoring_fit', '6011528bc482ba00041018ad');
@@ -63,9 +64,29 @@ final class CompetitionLogoFetcherTest extends TestCase
         );
     }
 
+    public function testFetchesScoringFitApiLogo(): void
+    {
+        $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse(json_encode([
+                'data' => [
+                    'competition' => [
+                        'iconLink' => 'https://scoring-images.s3.eu-west-3.amazonaws.com/events/68bbf76337b8e90033ff88e7/logo.jpg',
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR)),
+        ]));
+        $competition = new Competition('Camp Major', 'scoring_fit', '68bbf76337b8e90033ff88e7');
+
+        self::assertSame(
+            'https://scoring-images.s3.eu-west-3.amazonaws.com/events/68bbf76337b8e90033ff88e7/logo.jpg',
+            $fetcher->fetch($competition),
+        );
+    }
+
     public function testFetchesScoringFitStoredLogoFromExternalId(): void
     {
         $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('', ['http_code' => 404]),
             new MockResponse('', ['http_code' => 200]),
         ]));
         $competition = new Competition('Scoring Event', 'scoring_fit', '69a8200cf6c7b70033e2377e');
@@ -79,6 +100,7 @@ final class CompetitionLogoFetcherTest extends TestCase
     public function testReturnsNullWhenNoLogoIsPresent(): void
     {
         $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('', ['http_code' => 404]),
             new MockResponse('', ['http_code' => 404]),
             new MockResponse('<html>No logo here.</html>'),
         ]));


### PR DESCRIPTION
## Summary
- read Scoring.fit competition iconLink from the leaderboard API before S3 filename fallbacks
- keep existing logo.png and HTML parsing fallbacks for older/alternate cases
- cover API iconLink extraction in logo fetcher tests

## Tests
- php -l src/Services/Competition/CompetitionLogoFetcher.php
- php -l tests/CompetitionLogoFetcherTest.php
- php -d memory_limit=1G bin/phpunit --colors=always --filter CompetitionLogoFetcherTest