### PR TITLE
Validate Scoring.fit logo links

### DIFF
--- a/src/Command/BackfillCompetitionLogosCommand.php
+++ b/src/Command/BackfillCompetitionLogosCommand.php
@@ -52,6 +52,7 @@ final class BackfillCompetitionLogosCommand extends Command
 
         $inspected = 0;
         $updated = 0;
+        $cleared = 0;
         $missing = 0;
         $failed = 0;
         $pendingFlushes = 0;
@@ -72,6 +73,16 @@ final class BackfillCompetitionLogosCommand extends Command
             if ($logoUrl === null) {
                 ++$missing;
                 $io->writeln(sprintf('Missing %s (%s/%s)', $competition->getName(), $competition->getSourceName(), $competition->getExternalId()));
+                if ($force && $competition->getLogoUrl() !== null && !$dryRun) {
+                    $competition->setLogoUrl(null);
+                    ++$cleared;
+                    ++$pendingFlushes;
+
+                    if ($pendingFlushes >= 20) {
+                        $this->entityManager->flush();
+                        $pendingFlushes = 0;
+                    }
+                }
                 continue;
             }
 
@@ -96,6 +107,9 @@ final class BackfillCompetitionLogosCommand extends Command
             ['inspected', 'updated', 'missing', 'failed'],
             [[$inspected, $updated, $missing, $failed]],
         );
+        if ($cleared > 0) {
+            $io->writeln(sprintf('Cleared stale logos: %d', $cleared));
+        }
 
         if ($lastExternalId !== null && $externalIds === []) {
             $io->writeln(sprintf('Next cursor: --before-external-id=%s', $lastExternalId));

--- a/src/Services/Competition/CompetitionLogoFetcher.php
+++ b/src/Services/Competition/CompetitionLogoFetcher.php
@@ -192,7 +192,28 @@ final class CompetitionLogoFetcher
             return null;
         }
 
+        if (!$this->isPublicImageUrl($logoUrl)) {
+            return null;
+        }
+
         return $logoUrl;
+    }
+
+    private function isPublicImageUrl(string $url): bool
+    {
+        try {
+            $statusCode = $this->httpClient->request('GET', $url, [
+                'headers' => [
+                    'Range' => 'bytes=0-0',
+                ],
+            ])->getStatusCode();
+        } catch (TransportExceptionInterface $exception) {
+            throw new \RuntimeException(sprintf('Could not validate image URL %s.', $url), previous: $exception);
+        } catch (\Throwable) {
+            return false;
+        }
+
+        return $statusCode >= 200 && $statusCode < 300;
     }
 
     private function absoluteUrl(string $url, string $sourceUrl): string

--- a/tests/CompetitionLogoFetcherTest.php
+++ b/tests/CompetitionLogoFetcherTest.php
@@ -74,6 +74,7 @@ final class CompetitionLogoFetcherTest extends TestCase
                     ],
                 ],
             ], JSON_THROW_ON_ERROR)),
+            new MockResponse('x', ['http_code' => 206]),
         ]));
         $competition = new Competition('Camp Major', 'scoring_fit', '68bbf76337b8e90033ff88e7');
 
@@ -81,6 +82,25 @@ final class CompetitionLogoFetcherTest extends TestCase
             'https://scoring-images.s3.eu-west-3.amazonaws.com/events/68bbf76337b8e90033ff88e7/logo.jpg',
             $fetcher->fetch($competition),
         );
+    }
+
+    public function testSkipsPrivateScoringFitApiLogo(): void
+    {
+        $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse(json_encode([
+                'data' => [
+                    'competition' => [
+                        'iconLink' => 'https://scoring-images.s3.eu-west-3.amazonaws.com/private-logo.png',
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR)),
+            new MockResponse('', ['http_code' => 403]),
+            new MockResponse('', ['http_code' => 404]),
+            new MockResponse('<html>No logo here.</html>'),
+        ]));
+        $competition = new Competition('Private Logo', 'scoring_fit', '65c4e3d394353c0033aea8d6');
+
+        self::assertNull($fetcher->fetch($competition));
     }
 
     public function testFetchesScoringFitStoredLogoFromExternalId(): void


### PR DESCRIPTION
## Summary
- validate Scoring.fit API iconLink URLs before storing them as logos
- let forced logo backfills clear stale inaccessible logo URLs
- cover inaccessible iconLink fallback behavior in tests

## Tests
- php -l src/Services/Competition/CompetitionLogoFetcher.php
- php -l src/Command/BackfillCompetitionLogosCommand.php
- php -l tests/CompetitionLogoFetcherTest.php
- php -d memory_limit=1G bin/phpunit --colors=always --filter CompetitionLogoFetcherTest