### PR TITLE
Try Scoring.fit jpg event logos

### DIFF
--- a/src/Services/Competition/CompetitionLogoFetcher.php
+++ b/src/Services/Competition/CompetitionLogoFetcher.php
@@ -144,18 +144,20 @@ final class CompetitionLogoFetcher
             return null;
         }
 
-        $logoUrl = sprintf('https://scoring-images.s3.eu-west-3.amazonaws.com/events/%s/logo.png', $externalId);
+        foreach (['png', 'jpg'] as $extension) {
+            $logoUrl = sprintf('https://scoring-images.s3.eu-west-3.amazonaws.com/events/%s/logo.%s', $externalId, $extension);
 
-        try {
-            $statusCode = $this->httpClient->request('HEAD', $logoUrl)->getStatusCode();
-        } catch (TransportExceptionInterface $exception) {
-            throw new \RuntimeException(sprintf('Could not fetch Scoring.fit logo %s.', $logoUrl), previous: $exception);
-        } catch (\Throwable) {
-            return null;
-        }
+            try {
+                $statusCode = $this->httpClient->request('HEAD', $logoUrl)->getStatusCode();
+            } catch (TransportExceptionInterface $exception) {
+                throw new \RuntimeException(sprintf('Could not fetch Scoring.fit logo %s.', $logoUrl), previous: $exception);
+            } catch (\Throwable) {
+                continue;
+            }
 
-        if ($statusCode >= 200 && $statusCode < 300) {
-            return $logoUrl;
+            if ($statusCode >= 200 && $statusCode < 300) {
+                return $logoUrl;
+            }
         }
 
         return null;

--- a/tests/CompetitionLogoFetcherTest.php
+++ b/tests/CompetitionLogoFetcherTest.php
@@ -54,6 +54,7 @@ final class CompetitionLogoFetcherTest extends TestCase
         $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
             new MockResponse('', ['http_code' => 404]),
             new MockResponse('', ['http_code' => 404]),
+            new MockResponse('', ['http_code' => 404]),
             new MockResponse('<div class="hero-image-logo"><img src="https://scoring-images.s3.eu-west-3.amazonaws.com/events/logo.png?1779003354922" alt="logo"></div>'),
         ]));
         $competition = new Competition('Scoring Event', 'scoring_fit', '6011528bc482ba00041018ad');
@@ -96,6 +97,7 @@ final class CompetitionLogoFetcherTest extends TestCase
             ], JSON_THROW_ON_ERROR)),
             new MockResponse('', ['http_code' => 403]),
             new MockResponse('', ['http_code' => 404]),
+            new MockResponse('', ['http_code' => 404]),
             new MockResponse('<html>No logo here.</html>'),
         ]));
         $competition = new Competition('Private Logo', 'scoring_fit', '65c4e3d394353c0033aea8d6');
@@ -117,9 +119,25 @@ final class CompetitionLogoFetcherTest extends TestCase
         );
     }
 
+    public function testFetchesScoringFitStoredJpgLogoFromExternalId(): void
+    {
+        $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('', ['http_code' => 404]),
+            new MockResponse('', ['http_code' => 404]),
+            new MockResponse('', ['http_code' => 200]),
+        ]));
+        $competition = new Competition('Scoring Event', 'scoring_fit', '69b0ac15992e02003308503e');
+
+        self::assertSame(
+            'https://scoring-images.s3.eu-west-3.amazonaws.com/events/69b0ac15992e02003308503e/logo.jpg',
+            $fetcher->fetch($competition),
+        );
+    }
+
     public function testReturnsNullWhenNoLogoIsPresent(): void
     {
         $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse('', ['http_code' => 404]),
             new MockResponse('', ['http_code' => 404]),
             new MockResponse('', ['http_code' => 404]),
             new MockResponse('<html>No logo here.</html>'),


### PR DESCRIPTION
## Summary
- try both /events/{id}/logo.png and /events/{id}/logo.jpg for Scoring.fit logos
- keep API iconLink and HTML fallbacks intact
- add test coverage for jpg event logo fallback

## Tests
- php -l src/Services/Competition/CompetitionLogoFetcher.php
- php -l tests/CompetitionLogoFetcherTest.php
- php -d memory_limit=1G bin/phpunit --colors=always --filter CompetitionLogoFetcherTest