### PR TITLE
Treat unreachable logos as missing

### DIFF
--- a/src/Services/Competition/CompetitionLogoFetcher.php
+++ b/src/Services/Competition/CompetitionLogoFetcher.php
@@ -209,8 +209,8 @@ final class CompetitionLogoFetcher
                     'Range' => 'bytes=0-0',
                 ],
             ])->getStatusCode();
-        } catch (TransportExceptionInterface $exception) {
-            throw new \RuntimeException(sprintf('Could not validate image URL %s.', $url), previous: $exception);
+        } catch (TransportExceptionInterface) {
+            return false;
         } catch (\Throwable) {
             return false;
         }

--- a/tests/CompetitionLogoFetcherTest.php
+++ b/tests/CompetitionLogoFetcherTest.php
@@ -105,6 +105,26 @@ final class CompetitionLogoFetcherTest extends TestCase
         self::assertNull($fetcher->fetch($competition));
     }
 
+    public function testSkipsUnreachableScoringFitApiLogo(): void
+    {
+        $fetcher = new CompetitionLogoFetcher(new MockHttpClient([
+            new MockResponse(json_encode([
+                'data' => [
+                    'competition' => [
+                        'iconLink' => 'https://rsnatch.com/wp-content/uploads/2022/08/logo.png',
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR)),
+            new MockResponse('', ['error' => 'Could not resolve host: rsnatch.com']),
+            new MockResponse('', ['http_code' => 404]),
+            new MockResponse('', ['http_code' => 404]),
+            new MockResponse('<html>No logo here.</html>'),
+        ]));
+        $competition = new Competition('Unreachable Logo', 'scoring_fit', '62fc9a5c65709e0004c3f97e');
+
+        self::assertNull($fetcher->fetch($competition));
+    }
+
     public function testFetchesScoringFitStoredLogoFromExternalId(): void
     {
         $fetcher = new CompetitionLogoFetcher(new MockHttpClient([


### PR DESCRIPTION
## Summary
- treat unreachable image validation URLs as missing logos instead of failed backfill rows
- cover Scoring.fit API icon links that cannot be reached during validation

## Tests
- php -l src/Services/Competition/CompetitionLogoFetcher.php
- php -l tests/CompetitionLogoFetcherTest.php
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter CompetitionLogoFetcherTest