### PR TITLE
Add competition discovery metadata

### DIFF
--- a/migrations/Version20260517113000.php
+++ b/migrations/Version20260517113000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260517113000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add discovery metadata to competitions.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE competition ADD status VARCHAR(32) DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD starts_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD ends_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD registration_url VARCHAR(2048) DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD location_label VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD is_online BOOLEAN DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD competition_type VARCHAR(128) DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD participation_type VARCHAR(32) DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD cover_image_url VARCHAR(2048) DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD price_label VARCHAR(128) DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD metadata JSON DEFAULT NULL');
+        $this->addSql('ALTER TABLE competition ADD last_discovered_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('COMMENT ON COLUMN competition.starts_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('COMMENT ON COLUMN competition.ends_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('COMMENT ON COLUMN competition.last_discovered_at IS \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE competition DROP status');
+        $this->addSql('ALTER TABLE competition DROP starts_at');
+        $this->addSql('ALTER TABLE competition DROP ends_at');
+        $this->addSql('ALTER TABLE competition DROP registration_url');
+        $this->addSql('ALTER TABLE competition DROP location_label');
+        $this->addSql('ALTER TABLE competition DROP is_online');
+        $this->addSql('ALTER TABLE competition DROP competition_type');
+        $this->addSql('ALTER TABLE competition DROP participation_type');
+        $this->addSql('ALTER TABLE competition DROP cover_image_url');
+        $this->addSql('ALTER TABLE competition DROP price_label');
+        $this->addSql('ALTER TABLE competition DROP metadata');
+        $this->addSql('ALTER TABLE competition DROP last_discovered_at');
+    }
+}

--- a/src/Command/ImportCompetitionResultsCommand.php
+++ b/src/Command/ImportCompetitionResultsCommand.php
@@ -286,7 +286,19 @@ class ImportCompetitionResultsCommand extends Command
             ->setName($name)
             ->setSeason($this->intOrNull($row['season'] ?? null))
             ->setSourceUrl($sourceUrl)
-            ->setLogoUrl($this->stringOrNull($row['logoUrl'] ?? null));
+            ->setLogoUrl($this->stringOrNull($row['logoUrl'] ?? null))
+            ->setStatus($this->stringOrNull($row['status'] ?? null))
+            ->setStartsAt($this->dateTimeOrNull($row['startsAt'] ?? null))
+            ->setEndsAt($this->dateTimeOrNull($row['endsAt'] ?? null))
+            ->setRegistrationUrl($this->stringOrNull($row['registrationUrl'] ?? null))
+            ->setLocationLabel($this->stringOrNull($row['locationLabel'] ?? null))
+            ->setIsOnline($this->boolOrNull($row['isOnline'] ?? null))
+            ->setCompetitionType($this->stringOrNull($row['competitionType'] ?? null))
+            ->setParticipationType($this->stringOrNull($row['participationType'] ?? null))
+            ->setCoverImageUrl($this->stringOrNull($row['coverImageUrl'] ?? null))
+            ->setPriceLabel($this->stringOrNull($row['priceLabel'] ?? null))
+            ->setMetadata($this->arrayOrNull($row['metadata'] ?? null))
+            ->setLastDiscoveredAt($this->dateTimeOrNull($row['lastDiscoveredAt'] ?? null));
 
         return $status;
     }
@@ -676,6 +688,44 @@ class ImportCompetitionResultsCommand extends Command
         }
 
         return is_numeric($value) ? (float) $value : null;
+    }
+
+    private function boolOrNull(mixed $value): ?bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+    }
+
+    private function dateTimeOrNull(mixed $value): ?\DateTimeImmutable
+    {
+        $value = $this->stringOrNull($value);
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            return new \DateTimeImmutable($value);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function arrayOrNull(mixed $value): ?array
+    {
+        if (!is_array($value)) {
+            return null;
+        }
+
+        return $value;
     }
 
     private function hasFailures(): bool

--- a/src/Entity/Competition/Competition.php
+++ b/src/Entity/Competition/Competition.php
@@ -40,6 +40,45 @@ class Competition
     #[ORM\Column(length: 2048, nullable: true)]
     private ?string $logoUrl = null;
 
+    #[ORM\Column(length: 32, nullable: true)]
+    private ?string $status = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $startsAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $endsAt = null;
+
+    #[ORM\Column(length: 2048, nullable: true)]
+    private ?string $registrationUrl = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $locationLabel = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?bool $isOnline = null;
+
+    #[ORM\Column(length: 128, nullable: true)]
+    private ?string $competitionType = null;
+
+    #[ORM\Column(length: 32, nullable: true)]
+    private ?string $participationType = null;
+
+    #[ORM\Column(length: 2048, nullable: true)]
+    private ?string $coverImageUrl = null;
+
+    #[ORM\Column(length: 128, nullable: true)]
+    private ?string $priceLabel = null;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    #[ORM\Column(type: 'json', nullable: true)]
+    private ?array $metadata = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $lastDiscoveredAt = null;
+
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
 
@@ -121,6 +160,168 @@ class Competition
     public function setLogoUrl(?string $logoUrl): self
     {
         $this->logoUrl = $logoUrl;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(?string $status): self
+    {
+        $this->status = $status;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getStartsAt(): ?\DateTimeImmutable
+    {
+        return $this->startsAt;
+    }
+
+    public function setStartsAt(?\DateTimeImmutable $startsAt): self
+    {
+        $this->startsAt = $startsAt;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getEndsAt(): ?\DateTimeImmutable
+    {
+        return $this->endsAt;
+    }
+
+    public function setEndsAt(?\DateTimeImmutable $endsAt): self
+    {
+        $this->endsAt = $endsAt;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getRegistrationUrl(): ?string
+    {
+        return $this->registrationUrl;
+    }
+
+    public function setRegistrationUrl(?string $registrationUrl): self
+    {
+        $this->registrationUrl = $registrationUrl;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getLocationLabel(): ?string
+    {
+        return $this->locationLabel;
+    }
+
+    public function setLocationLabel(?string $locationLabel): self
+    {
+        $this->locationLabel = $locationLabel;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function isOnline(): ?bool
+    {
+        return $this->isOnline;
+    }
+
+    public function setIsOnline(?bool $isOnline): self
+    {
+        $this->isOnline = $isOnline;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getCompetitionType(): ?string
+    {
+        return $this->competitionType;
+    }
+
+    public function setCompetitionType(?string $competitionType): self
+    {
+        $this->competitionType = $competitionType;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getParticipationType(): ?string
+    {
+        return $this->participationType;
+    }
+
+    public function setParticipationType(?string $participationType): self
+    {
+        $this->participationType = $participationType;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getCoverImageUrl(): ?string
+    {
+        return $this->coverImageUrl;
+    }
+
+    public function setCoverImageUrl(?string $coverImageUrl): self
+    {
+        $this->coverImageUrl = $coverImageUrl;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getPriceLabel(): ?string
+    {
+        return $this->priceLabel;
+    }
+
+    public function setPriceLabel(?string $priceLabel): self
+    {
+        $this->priceLabel = $priceLabel;
+        $this->touch();
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getMetadata(): ?array
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * @param array<string, mixed>|null $metadata
+     */
+    public function setMetadata(?array $metadata): self
+    {
+        $this->metadata = $metadata;
+        $this->touch();
+
+        return $this;
+    }
+
+    public function getLastDiscoveredAt(): ?\DateTimeImmutable
+    {
+        return $this->lastDiscoveredAt;
+    }
+
+    public function setLastDiscoveredAt(?\DateTimeImmutable $lastDiscoveredAt): self
+    {
+        $this->lastDiscoveredAt = $lastDiscoveredAt;
         $this->touch();
 
         return $this;

--- a/tests/ImportCompetitionResultsCommandTest.php
+++ b/tests/ImportCompetitionResultsCommandTest.php
@@ -94,6 +94,18 @@ class ImportCompetitionResultsCommandTest extends AbstractIntegrationTest
                     'name' => 'CrossFit Games',
                     'season' => 2024,
                     'logoUrl' => 'https://example.test/crossfit-games.png',
+                    'status' => 'past',
+                    'startsAt' => '2024-08-08T12:00:00+00:00',
+                    'endsAt' => '2024-08-11T20:00:00+00:00',
+                    'registrationUrl' => 'https://example.test/register',
+                    'locationLabel' => 'Fort Worth, TX',
+                    'isOnline' => false,
+                    'competitionType' => 'functional_fitness',
+                    'participationType' => 'individual',
+                    'coverImageUrl' => 'https://example.test/cover.jpg',
+                    'priceLabel' => '$25',
+                    'metadata' => ['sourceCategory' => 'Games'],
+                    'lastDiscoveredAt' => '2026-05-17T10:30:00+00:00',
                 ],
             ],
             'events' => [
@@ -161,6 +173,18 @@ class ImportCompetitionResultsCommandTest extends AbstractIntegrationTest
             ]);
             self::assertNotNull($competition);
             self::assertSame('https://example.test/crossfit-games.png', $competition->getLogoUrl());
+            self::assertSame('past', $competition->getStatus());
+            self::assertSame('2024-08-08T12:00:00+00:00', $competition->getStartsAt()?->format(DATE_ATOM));
+            self::assertSame('2024-08-11T20:00:00+00:00', $competition->getEndsAt()?->format(DATE_ATOM));
+            self::assertSame('https://example.test/register', $competition->getRegistrationUrl());
+            self::assertSame('Fort Worth, TX', $competition->getLocationLabel());
+            self::assertFalse($competition->isOnline());
+            self::assertSame('functional_fitness', $competition->getCompetitionType());
+            self::assertSame('individual', $competition->getParticipationType());
+            self::assertSame('https://example.test/cover.jpg', $competition->getCoverImageUrl());
+            self::assertSame('$25', $competition->getPriceLabel());
+            self::assertSame(['sourceCategory' => 'Games'], $competition->getMetadata());
+            self::assertSame('2026-05-17T10:30:00+00:00', $competition->getLastDiscoveredAt()?->format(DATE_ATOM));
         } finally {
             @unlink($file);
         }


### PR DESCRIPTION
## Summary
- add optional discovery metadata fields to competitions
- import competition dates, status, location, registration URL, type, participation mode, cover image, price label, and raw metadata from the existing JSON contract
- cover the new import fields in the competition import workflow test

## Tests
- php -l src/Entity/Competition/Competition.php
- php -l src/Command/ImportCompetitionResultsCommand.php
- php -l migrations/Version20260517113000.php
- php -l tests/ImportCompetitionResultsCommandTest.php
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php bin/console doctrine:migrations:migrate --env=test --no-interaction
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter ImportCompetitionResultsCommandTest