### PR TITLE
Match workout movement filters by catalog name

### DIFF
--- a/src/Repository/Workout/MovementRepository.php
+++ b/src/Repository/Workout/MovementRepository.php
@@ -53,31 +53,24 @@ class MovementRepository extends ServiceEntityRepository implements MovementRepo
         $query = $this->createQueryBuilder('m');
 
         if (count($movementTypes) > 0) {
-            $typeOrX = $query->expr()->orX();
-            foreach ($movementTypes as $idx => $movementType) {
-                $typeOrX->add('m.movementType = :movementType'.$idx);
-                $query->setParameter('movementType'.$idx, $movementType);
-            }
-            $query->andWhere($typeOrX);
+            $query
+                ->join('m.movementType', 'mt')
+                ->andWhere('mt.name IN (:movementTypeNames)')
+                ->setParameter('movementTypeNames', $this->entityNames($movementTypes));
         }
 
         if (count($difficulties) > 0) {
-            $diffOrX = $query->expr()->orX();
-            foreach ($difficulties as $idx => $difficulty) {
-                $diffOrX->add('m.difficulty = :difficulty'.$idx);
-                $query->setParameter('difficulty'.$idx, $difficulty);
-            }
-            $query->andWhere($diffOrX);
+            $query
+                ->join('m.difficulty', 'md')
+                ->andWhere('md.name IN (:difficultyNames)')
+                ->setParameter('difficultyNames', $this->entityNames($difficulties));
         }
 
         if (count($implements) > 0) {
-            $diffOrX = $query->expr()->orX();
-            $query->join('m.possibleImplements', 'pi');
-            foreach ($implements as $idx => $implement) {
-                $diffOrX->add(':implement'.$idx.' = pi');
-                $query->setParameter('implement'.$idx, $implement);
-            }
-            $query->andWhere($diffOrX);
+            $query
+                ->join('m.possibleImplements', 'pi')
+                ->andWhere('pi.name IN (:implementNames)')
+                ->setParameter('implementNames', $this->entityNames($implements));
         }
 
         if (count($movementsToExclude) > 0) {
@@ -109,42 +102,33 @@ class MovementRepository extends ServiceEntityRepository implements MovementRepo
         $query = $this->createQueryBuilder('m');
 
         if (count($movementTypes) > 0) {
-            $typeOrX = $query->expr()->orX();
-            foreach ($movementTypes as $idx => $movementType) {
-                $typeOrX->add('m.movementType = :movementType'.$idx);
-                $query->setParameter('movementType'.$idx, $movementType);
-            }
-            $query->andWhere($typeOrX);
+            $query
+                ->join('m.movementType', 'mt')
+                ->andWhere('mt.name IN (:movementTypeNames)')
+                ->setParameter('movementTypeNames', $this->entityNames($movementTypes));
         }
 
         if (count($difficulties) > 0) {
-            $diffOrX = $query->expr()->orX();
-            foreach ($difficulties as $idx => $difficulty) {
-                $diffOrX->add('m.difficulty = :difficulty'.$idx);
-                $query->setParameter('difficulty'.$idx, $difficulty);
-            }
-            $query->andWhere($diffOrX);
+            $query
+                ->join('m.difficulty', 'md')
+                ->andWhere('md.name IN (:difficultyNames)')
+                ->setParameter('difficultyNames', $this->entityNames($difficulties));
         }
 
         if (count($implements) > 0) {
-            $diffOrX = $query->expr()->orX();
-            foreach ($implements as $idx => $implement) {
-                $diffOrX->add(':implement'.$idx.' MEMBER OF m.possibleImplements');
-                $query->setParameter('implement'.$idx, $implement);
-            }
-            $query->andWhere($diffOrX);
+            $query
+                ->join('m.possibleImplements', 'pi')
+                ->andWhere('pi.name IN (:implementNames)')
+                ->setParameter('implementNames', $this->entityNames($implements));
         }
 
         if (count($bodyParts) > 0) {
             $query->join('m.muscles', 'mm')
                 ->join('mm.bodyPart', 'bp');
 
-            $bodyPartOrX = $query->expr()->orX();
-            foreach ($bodyParts as $idx => $bodyPart) {
-                $bodyPartOrX->add('bp = :bodyPart'.$idx);
-                $query->setParameter('bodyPart'.$idx, $bodyPart);
-            }
-            $query->andWhere($bodyPartOrX);
+            $query
+                ->andWhere('bp.name IN (:bodyPartNames)')
+                ->setParameter('bodyPartNames', $this->entityNames($bodyParts));
         }
 
         if (count($movementsToExclude) > 0) {
@@ -156,5 +140,13 @@ class MovementRepository extends ServiceEntityRepository implements MovementRepo
         return $query
             ->getQuery()
             ->getResult();
+    }
+
+    private function entityNames(array $entities): array
+    {
+        return array_values(array_unique(array_map(
+            static fn (object $entity): string => $entity->getName(),
+            $entities,
+        )));
     }
 }

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -11,7 +11,19 @@ use App\Entity\Competition\CompetitionEvent;
 use App\Entity\Competition\Enum\ScoreTypeEnum;
 use App\Entity\Competition\Score;
 use App\Entity\Competition\WorkoutResult;
+use App\Entity\Workout\BodyPart;
+use App\Entity\Workout\Enum\BodyPartEnum;
+use App\Entity\Workout\Enum\ImplementEnum;
+use App\Entity\Workout\Enum\MovementDifficultyEnum;
+use App\Entity\Workout\Enum\MovementTypeEnum;
+use App\Entity\Workout\Enum\WorkoutMovementGenerationTypeEnum;
+use App\Entity\Workout\Enum\WorkoutTypeEnum;
+use App\Entity\Workout\Implement;
+use App\Entity\Workout\MovementDifficulty;
+use App\Entity\Workout\MovementType;
 use App\Entity\Workout\Workout;
+use App\Entity\Workout\WorkoutMovementGenerationType;
+use App\Entity\Workout\WorkoutType;
 use App\Entity\WorkoutGeneration\WorkoutGeneration;
 
 class WorkoutApiWorkflowTest extends AbstractIntegrationTest
@@ -426,5 +438,57 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         self::assertCount(1, $updatedDraft['mandatoryMovements']);
 
         self::assertNotNull($this->getRepository(WorkoutGeneration::class)->find($draft['id']));
+    }
+
+    public function testWorkoutGenerationMatchesCatalogFiltersByNameWhenCatalogRowsAreDuplicated(): void
+    {
+        $entityManager = $this->getEntityManager();
+        $duplicateCardio = new MovementType(MovementTypeEnum::CARDIO);
+        $duplicateWeightlifting = new MovementType(MovementTypeEnum::WEIGHTLIFTING);
+        $duplicateGymnastic = new MovementType(MovementTypeEnum::GYMNASTIC);
+        $duplicateElite = new MovementDifficulty(MovementDifficultyEnum::ELITE);
+        $duplicateBarbell = new Implement(ImplementEnum::BARBELL, null);
+        $duplicatePullUpBar = new Implement(ImplementEnum::PULL_UP_BAR, null);
+        $duplicateLegs = new BodyPart(BodyPartEnum::LEGS);
+        $duplicateUpperBack = new BodyPart(BodyPartEnum::UPPER_BACK);
+
+        foreach ([
+            $duplicateCardio,
+            $duplicateWeightlifting,
+            $duplicateGymnastic,
+            $duplicateElite,
+            $duplicateBarbell,
+            $duplicatePullUpBar,
+            $duplicateLegs,
+            $duplicateUpperBack,
+        ] as $entity) {
+            $entityManager->persist($entity);
+        }
+
+        $workoutGeneration = (new WorkoutGeneration())
+            ->setName('Duplicated catalog WOD')
+            ->setTimeCap(16)
+            ->setWorkoutType(new WorkoutType(WorkoutTypeEnum::FOR_TIME))
+            ->setMovementGenerationType(new WorkoutMovementGenerationType(WorkoutMovementGenerationTypeEnum::MOVEMENT))
+            ->setMovementDifficulty($duplicateElite)
+            ->setMovementTypes([$duplicateCardio, $duplicateWeightlifting, $duplicateGymnastic])
+            ->setAvailableImplements([$duplicateBarbell, $duplicatePullUpBar])
+            ->setMandatoryBodyParts([$duplicateLegs, $duplicateUpperBack])
+            ->setNumberOfDifferentMovements(3)
+            ->setNumberOfRounds(3)
+            ->setIsTeamWorkout(true);
+
+        $entityManager->persist($workoutGeneration);
+        $entityManager->flush();
+        $entityManager->clear();
+
+        $this->browser()->request('GET', sprintf('/api/workout-generation-flow/%s/possible-movements', $workoutGeneration->getId()));
+
+        self::assertResponseIsSuccessful();
+
+        $payload = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $movementNames = array_column($payload['movements'], 'name');
+
+        self::assertContains('Deadlift', $movementNames);
     }
 }


### PR DESCRIPTION
## Summary
- match movement type, difficulty, implement, and body-part filters by catalog name instead of row identity
- keep the generator resilient when production has duplicate catalog rows from historical imports
- add a regression test for duplicated catalog rows still returning possible movements

## Tests
- composer cs:fix
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter 'testFrontendCanCreateAndUpdateWorkoutGenerationDraft|testWorkoutGenerationMatchesCatalogFiltersByNameWhenCatalogRowsAreDuplicated'