### PR TITLE
Use configured model for workout generation

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,6 +36,7 @@ services:
         public: true
         arguments:
             $chatGPTApiKey: '%env(CHAT_GPT_API_KEY)%'
+            $openAiModel: '%env(OPENAI_MODEL)%'
 
     App\Services\Competition\AthletePublicAnalysisGenerator:
         arguments:

--- a/src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
+++ b/src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
@@ -98,7 +98,14 @@ class WorkoutGenerationFlowController extends AbstractController
             return $this->json(['error' => 'Workout generation not found'], Response::HTTP_NOT_FOUND);
         }
 
-        $workout = $this->workoutCreator->createWorkout($workoutGeneration);
+        try {
+            $workout = $this->workoutCreator->createWorkout($workoutGeneration);
+        } catch (\InvalidArgumentException $exception) {
+            return $this->json(['error' => $exception->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+        } catch (\RuntimeException $exception) {
+            return $this->json(['error' => $exception->getMessage()], Response::HTTP_BAD_GATEWAY);
+        }
+
         $this->entityManager->persist($workout);
         $this->entityManager->flush();
 

--- a/src/Services/Workout/ChatGPTApiKey.php
+++ b/src/Services/Workout/ChatGPTApiKey.php
@@ -13,12 +13,17 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
 {
     public function __construct(
         public string $chatGPTApiKey,
+        private string $openAiModel,
         private HttpClientInterface $client,
     ) {
     }
 
     public function getWorkoutFlowFromPrompt(string $prompt): string
     {
+        if (trim($this->chatGPTApiKey) === '') {
+            throw new \RuntimeException('CHAT_GPT_API_KEY is required to generate workouts.');
+        }
+
         //        $client = $this->client->withOptions([
         //            'base_uri' => 'https://api.openai.com/v1/',
         //            'headers' =>
@@ -40,7 +45,7 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
                     'Content-Type' => 'application/json',
                 ],
                 'json' => [
-                    'model' => 'gpt-3.5-turbo',
+                    'model' => $this->openAiModel,
                     'messages' => [
                         ['role' => 'user', 'content' => $prompt],
                     ],
@@ -56,9 +61,14 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
         RedirectionExceptionInterface|
         ServerExceptionInterface|
         TransportExceptionInterface $e) {
-            return 'Error: '.$e->getMessage();
+            throw new \RuntimeException('OpenAI workout generation failed: '.$e->getMessage(), 0, $e);
         }
 
-        return $data['choices'][0]['message']['content'] ?? '';
+        $content = trim((string) ($data['choices'][0]['message']['content'] ?? ''));
+        if ($content === '') {
+            throw new \RuntimeException('OpenAI workout generation returned an empty response.');
+        }
+
+        return $content;
     }
 }

--- a/src/Services/Workout/MovementService.php
+++ b/src/Services/Workout/MovementService.php
@@ -103,7 +103,12 @@ readonly class MovementService implements MovementServiceInterface
 
         // once we filled with not used type of movements, we fill with any possible movement
         while (count($movementsInWorkout) < $workoutGeneration->getNumberOfDifferentMovements()) {
-            $movementsInWorkout[] = array_pop($possibleMovements);
+            $movement = array_pop($possibleMovements);
+            if (!$movement instanceof Movement) {
+                throw new \InvalidArgumentException(sprintf('Pas assez de mouvements correspondent aux critères actuels (%d demandé%s, %d disponible%s).', $workoutGeneration->getNumberOfDifferentMovements(), $workoutGeneration->getNumberOfDifferentMovements() > 1 ? 's' : '', count($movementsInWorkout), count($movementsInWorkout) > 1 ? 's' : ''));
+            }
+
+            $movementsInWorkout[] = $movement;
         }
 
         return $movementsInWorkout;


### PR DESCRIPTION
## Summary
- use OPENAI_MODEL for workout generation instead of the hardcoded legacy model
- return readable API errors when OpenAI generation fails
- guard movement selection when requested movement count exceeds available matches

## Tests
- php -l src/Services/Workout/ChatGPTApiKey.php
- php -l src/Services/Workout/MovementService.php
- php -l src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutApiWorkflowTest