### PR TITLE
Fix OpenAI workout generation token parameter

### DIFF
--- a/src/Services/Workout/ChatGPTApiKey.php
+++ b/src/Services/Workout/ChatGPTApiKey.php
@@ -49,7 +49,7 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
                     'messages' => [
                         ['role' => 'user', 'content' => $prompt],
                     ],
-                    'max_tokens' => 512,
+                    'max_completion_tokens' => 512,
                 ],
             ]
         );
@@ -61,7 +61,7 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
         RedirectionExceptionInterface|
         ServerExceptionInterface|
         TransportExceptionInterface $e) {
-            throw new \RuntimeException('OpenAI workout generation failed: '.$e->getMessage(), 0, $e);
+            throw new \RuntimeException('OpenAI workout generation failed: '.$this->errorMessage($e), 0, $e);
         }
 
         $content = trim((string) ($data['choices'][0]['message']['content'] ?? ''));
@@ -70,5 +70,18 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
         }
 
         return $content;
+    }
+
+    private function errorMessage(\Throwable $exception): string
+    {
+        if (method_exists($exception, 'getResponse')) {
+            $response = $exception->getResponse();
+            $content = trim($response->getContent(false));
+            if ($content !== '') {
+                return $content;
+            }
+        }
+
+        return $exception->getMessage();
     }
 }

--- a/tests/ChatGPTApiKeyTest.php
+++ b/tests/ChatGPTApiKeyTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Tests;
+
+use App\Services\Workout\ChatGPTApiKey;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class ChatGPTApiKeyTest extends TestCase
+{
+    public function testWorkoutGenerationUsesConfiguredModelAndModernTokenParameter(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options): MockResponse {
+            $payload = $this->payloadFromOptions($options);
+
+            self::assertSame('POST', $method);
+            self::assertSame('https://api.openai.com/v1/chat/completions', $url);
+            self::assertSame('gpt-5.4-mini', $payload['model']);
+            self::assertArrayHasKey('max_completion_tokens', $payload);
+            self::assertArrayNotHasKey('max_tokens', $payload);
+
+            return new MockResponse(json_encode([
+                'choices' => [
+                    ['message' => ['content' => 'AMRAP 12 minutes']],
+                ],
+            ], JSON_THROW_ON_ERROR));
+        });
+
+        $client = new ChatGPTApiKey('test-key', 'gpt-5.4-mini', $httpClient);
+
+        self::assertSame('AMRAP 12 minutes', $client->getWorkoutFlowFromPrompt('Create a workout.'));
+    }
+
+    public function testWorkoutGenerationErrorIncludesOpenAiResponseBody(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse(json_encode([
+                'error' => ['message' => 'Unsupported parameter: max_tokens'],
+            ], JSON_THROW_ON_ERROR), ['http_code' => 400]),
+        ]);
+        $client = new ChatGPTApiKey('test-key', 'gpt-5.4-mini', $httpClient);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported parameter: max_tokens');
+
+        $client->getWorkoutFlowFromPrompt('Create a workout.');
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function payloadFromOptions(array $options): array
+    {
+        self::assertArrayHasKey('body', $options);
+        self::assertIsString($options['body']);
+
+        $payload = json_decode($options['body'], true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+
+        return $payload;
+    }
+}


### PR DESCRIPTION
## Summary
- replace the legacy chat completions max_tokens parameter with max_completion_tokens for configured modern models
- include the OpenAI response body in workout generation errors
- add unit coverage for the OpenAI workout payload and error details

## Tests
- php -l src/Services/Workout/ChatGPTApiKey.php
- php -l tests/ChatGPTApiKeyTest.php
- composer cs:check
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter ChatGPTApiKeyTest
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter 'ChatGPTApiKeyTest|WorkoutApiWorkflowTest'