### PR TITLE
Use Responses API for workout generation

### DIFF
--- a/src/Services/Workout/ChatGPTApiKey.php
+++ b/src/Services/Workout/ChatGPTApiKey.php
@@ -38,7 +38,7 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
 
         $response = $this->client->request(
             'POST',
-            'https://api.openai.com/v1/chat/completions',
+            'https://api.openai.com/v1/responses',
             [
                 'headers' => [
                     'Authorization' => 'Bearer '.$this->chatGPTApiKey,
@@ -46,10 +46,10 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
                 ],
                 'json' => [
                     'model' => $this->openAiModel,
-                    'messages' => [
+                    'input' => [
                         ['role' => 'user', 'content' => $prompt],
                     ],
-                    'max_completion_tokens' => 512,
+                    'max_output_tokens' => 1024,
                 ],
             ]
         );
@@ -64,7 +64,10 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
             throw new \RuntimeException('OpenAI workout generation failed: '.$this->errorMessage($e), 0, $e);
         }
 
-        $content = trim((string) ($data['choices'][0]['message']['content'] ?? ''));
+        $content = trim((string) ($data['output_text'] ?? ''));
+        if ($content === '') {
+            $content = $this->extractOutputText($data);
+        }
         if ($content === '') {
             throw new \RuntimeException('OpenAI workout generation returned an empty response.');
         }
@@ -76,12 +79,40 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
     {
         if (method_exists($exception, 'getResponse')) {
             $response = $exception->getResponse();
-            $content = trim($response->getContent(false));
-            if ($content !== '') {
-                return $content;
+            try {
+                $content = trim($response->getContent(false));
+                if ($content !== '') {
+                    return $content;
+                }
+            } catch (\Throwable) {
+                // Keep the original exception message if the error body cannot be read.
             }
         }
 
         return $exception->getMessage();
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function extractOutputText(array $data): string
+    {
+        $parts = [];
+        foreach (($data['output'] ?? []) as $output) {
+            if (!is_array($output)) {
+                continue;
+            }
+            foreach (($output['content'] ?? []) as $content) {
+                if (!is_array($content)) {
+                    continue;
+                }
+                $text = $content['text'] ?? null;
+                if (is_string($text) && $text !== '') {
+                    $parts[] = $text;
+                }
+            }
+        }
+
+        return trim(implode("\n", $parts));
     }
 }

--- a/tests/ChatGPTApiKeyTest.php
+++ b/tests/ChatGPTApiKeyTest.php
@@ -9,27 +9,46 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 final class ChatGPTApiKeyTest extends TestCase
 {
-    public function testWorkoutGenerationUsesConfiguredModelAndModernTokenParameter(): void
+    public function testWorkoutGenerationUsesResponsesApiWithConfiguredModelAndModernTokenParameter(): void
     {
         $httpClient = new MockHttpClient(function (string $method, string $url, array $options): MockResponse {
             $payload = $this->payloadFromOptions($options);
 
             self::assertSame('POST', $method);
-            self::assertSame('https://api.openai.com/v1/chat/completions', $url);
+            self::assertSame('https://api.openai.com/v1/responses', $url);
             self::assertSame('gpt-5.4-mini', $payload['model']);
-            self::assertArrayHasKey('max_completion_tokens', $payload);
+            self::assertArrayHasKey('max_output_tokens', $payload);
             self::assertArrayNotHasKey('max_tokens', $payload);
+            self::assertArrayNotHasKey('max_completion_tokens', $payload);
+            self::assertSame('Create a workout.', $payload['input'][0]['content']);
 
             return new MockResponse(json_encode([
-                'choices' => [
-                    ['message' => ['content' => 'AMRAP 12 minutes']],
-                ],
+                'output_text' => 'AMRAP 12 minutes',
             ], JSON_THROW_ON_ERROR));
         });
 
         $client = new ChatGPTApiKey('test-key', 'gpt-5.4-mini', $httpClient);
 
         self::assertSame('AMRAP 12 minutes', $client->getWorkoutFlowFromPrompt('Create a workout.'));
+    }
+
+    public function testWorkoutGenerationReadsResponsesOutputContentWhenOutputTextIsMissing(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse(json_encode([
+                'output' => [
+                    [
+                        'content' => [
+                            ['text' => 'For time'],
+                            ['text' => '21-15-9 row and burpees'],
+                        ],
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+        $client = new ChatGPTApiKey('test-key', 'gpt-5.4-mini', $httpClient);
+
+        self::assertSame("For time\n21-15-9 row and burpees", $client->getWorkoutFlowFromPrompt('Create a workout.'));
     }
 
     public function testWorkoutGenerationErrorIncludesOpenAiResponseBody(): void


### PR DESCRIPTION
## Summary
- move workout generation from Chat Completions to OpenAI Responses API
- use max_output_tokens and parse both output_text and structured output content
- harden OpenAI error extraction so error bodies do not become opaque 500s

## Tests
- php -l src/Services/Workout/ChatGPTApiKey.php
- php -l tests/ChatGPTApiKeyTest.php
- composer cs:check
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter ChatGPTApiKeyTest

Note: local WorkoutApiWorkflowTest could not run because the local PostgreSQL test database refused the connection; CI covers the integration suite.