### PR TITLE
Harden workout generation error handling

### DIFF
--- a/src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
+++ b/src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
@@ -100,14 +100,17 @@ class WorkoutGenerationFlowController extends AbstractController
 
         try {
             $workout = $this->workoutCreator->createWorkout($workoutGeneration);
+            $this->entityManager->persist($workout);
+            $this->entityManager->flush();
         } catch (\InvalidArgumentException $exception) {
             return $this->json(['error' => $exception->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
         } catch (\RuntimeException $exception) {
             return $this->json(['error' => $exception->getMessage()], Response::HTTP_BAD_GATEWAY);
+        } catch (\Throwable $exception) {
+            return $this->json([
+                'error' => sprintf('Workout generation failed: %s: %s', $exception::class, $exception->getMessage()),
+            ], Response::HTTP_BAD_GATEWAY);
         }
-
-        $this->entityManager->persist($workout);
-        $this->entityManager->flush();
 
         return $this->json($this->serializeWorkout($workout), Response::HTTP_CREATED);
     }

--- a/src/Services/Workout/ChatGPTApiKey.php
+++ b/src/Services/Workout/ChatGPTApiKey.php
@@ -46,9 +46,7 @@ readonly class ChatGPTApiKey implements ChatGPTApiKeyInterface
                 ],
                 'json' => [
                     'model' => $this->openAiModel,
-                    'input' => [
-                        ['role' => 'user', 'content' => $prompt],
-                    ],
+                    'input' => $prompt,
                     'max_output_tokens' => 1024,
                 ],
             ]

--- a/tests/ChatGPTApiKeyTest.php
+++ b/tests/ChatGPTApiKeyTest.php
@@ -20,7 +20,7 @@ final class ChatGPTApiKeyTest extends TestCase
             self::assertArrayHasKey('max_output_tokens', $payload);
             self::assertArrayNotHasKey('max_tokens', $payload);
             self::assertArrayNotHasKey('max_completion_tokens', $payload);
-            self::assertSame('Create a workout.', $payload['input'][0]['content']);
+            self::assertSame('Create a workout.', $payload['input']);
 
             return new MockResponse(json_encode([
                 'output_text' => 'AMRAP 12 minutes',


### PR DESCRIPTION
## Summary
- send OpenAI Responses input as a plain text prompt
- catch persistence and unexpected generation errors so the endpoint returns a readable JSON error instead of a raw 500
- keep the Responses API payload covered by tests

## Tests
- php -l src/Services/Workout/ChatGPTApiKey.php
- php -l src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
- php -l tests/ChatGPTApiKeyTest.php
- composer cs:check
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter ChatGPTApiKeyTest