### PR TITLE
Allow regenerating workout generation drafts

### DIFF
--- a/src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
+++ b/src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
@@ -100,6 +100,7 @@ class WorkoutGenerationFlowController extends AbstractController
 
         try {
             $workout = $this->workoutCreator->createWorkout($workoutGeneration);
+            $workout = $this->upsertGeneratedWorkout($workoutGeneration, $workout);
             $this->entityManager->persist($workout);
             $this->entityManager->flush();
         } catch (\InvalidArgumentException $exception) {
@@ -113,6 +114,40 @@ class WorkoutGenerationFlowController extends AbstractController
         }
 
         return $this->json($this->serializeWorkout($workout), Response::HTTP_CREATED);
+    }
+
+    private function upsertGeneratedWorkout(WorkoutGeneration $workoutGeneration, Workout $generatedWorkout): Workout
+    {
+        $existingWorkout = $this->entityManager->getRepository(Workout::class)->findOneBy([
+            'workoutGeneration' => $workoutGeneration,
+        ]);
+
+        if (!$existingWorkout instanceof Workout) {
+            return $generatedWorkout;
+        }
+
+        $existingWorkout
+            ->setName($generatedWorkout->getName())
+            ->setFlow($generatedWorkout->getFlow())
+            ->setNumberOfRounds($generatedWorkout->getNumberOfRounds())
+            ->setTimeCap($generatedWorkout->getTimeCap())
+            ->setWorkoutType($generatedWorkout->getWorkoutType())
+            ->setWorkoutOrigin($generatedWorkout->getWorkoutOrigin());
+
+        foreach ($existingWorkout->getImplements()->toArray() as $implement) {
+            $existingWorkout->removeImplement($implement);
+        }
+        foreach ($generatedWorkout->getImplements() as $implement) {
+            $existingWorkout->addImplement($implement);
+        }
+        foreach ($existingWorkout->getMovements()->toArray() as $movement) {
+            $existingWorkout->removeMovement($movement);
+        }
+        foreach ($generatedWorkout->getMovements() as $movement) {
+            $existingWorkout->addMovement($movement);
+        }
+
+        return $existingWorkout;
     }
 
     private function hydrate(WorkoutGeneration $workoutGeneration, array $payload): void
@@ -313,7 +348,7 @@ class WorkoutGenerationFlowController extends AbstractController
     private function serializeWorkout(Workout $workout): array
     {
         return [
-            'id' => $workout->getId()->toString(),
+            'id' => $workout->getId()?->toString(),
             'name' => $workout->getName(),
             'flow' => $workout->getFlow(),
             'timeCap' => $workout->getTimeCap(),

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -17,14 +17,18 @@ use App\Entity\Workout\Enum\ImplementEnum;
 use App\Entity\Workout\Enum\MovementDifficultyEnum;
 use App\Entity\Workout\Enum\MovementTypeEnum;
 use App\Entity\Workout\Enum\WorkoutMovementGenerationTypeEnum;
+use App\Entity\Workout\Enum\WorkoutOriginNameEnum;
 use App\Entity\Workout\Enum\WorkoutTypeEnum;
 use App\Entity\Workout\Implement;
 use App\Entity\Workout\MovementDifficulty;
 use App\Entity\Workout\MovementType;
 use App\Entity\Workout\Workout;
 use App\Entity\Workout\WorkoutMovementGenerationType;
+use App\Entity\Workout\WorkoutOrigin;
+use App\Entity\Workout\WorkoutOriginName;
 use App\Entity\Workout\WorkoutType;
 use App\Entity\WorkoutGeneration\WorkoutGeneration;
+use App\Services\Workout\WorkoutCreatorServiceInterface;
 
 class WorkoutApiWorkflowTest extends AbstractIntegrationTest
 {
@@ -438,6 +442,66 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         self::assertCount(1, $updatedDraft['mandatoryMovements']);
 
         self::assertNotNull($this->getRepository(WorkoutGeneration::class)->find($draft['id']));
+    }
+
+    public function testFrontendCanRegenerateWorkoutForTheSameDraft(): void
+    {
+        $this->browser()->disableReboot();
+        static::getContainer()->set(WorkoutCreatorServiceInterface::class, new class implements WorkoutCreatorServiceInterface {
+            public function createWorkout(WorkoutGeneration $workoutGeneration): Workout
+            {
+                return (new Workout(
+                    $workoutGeneration->getName(),
+                    'Generated flow',
+                    $workoutGeneration->getNumberOfRounds(),
+                    $workoutGeneration->getTimeCap(),
+                    $workoutGeneration->getWorkoutType(),
+                    new WorkoutOrigin(new WorkoutOriginName(WorkoutOriginNameEnum::CUSTOM), 2026),
+                    $workoutGeneration->getAvailableImplements()->toArray(),
+                    $workoutGeneration->getMandatoryMovements()->toArray(),
+                ))->setWorkoutGeneration($workoutGeneration);
+            }
+        });
+
+        $this->browser()->request(
+            'POST',
+            '/api/workout-generation-flow',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'name' => 'Regenerated WOD',
+                'timeCap' => 15,
+                'movementGenerationType' => 'selected movements',
+                'workoutType' => 'AMRAP',
+                'numberOfRounds' => 1,
+                'movementTypes' => ['Weightlifting'],
+                'isTeamWorkout' => false,
+                'movementDifficulty' => 'Intermediate',
+                'mandatoryBodyParts' => [],
+                'availableImplements' => ['barbell'],
+                'numberOfDifferentMovements' => 1,
+                'bannedMovements' => [],
+                'mandatoryMovements' => [],
+                'intervalsTime' => null,
+                'intervalsRestTime' => null,
+            ], JSON_THROW_ON_ERROR)
+        );
+        self::assertResponseStatusCodeSame(201);
+        $draft = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->browser()->request('POST', sprintf('/api/workout-generation-flow/%s/workout', $draft['id']));
+        self::assertResponseStatusCodeSame(201);
+        $firstWorkout = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->browser()->request('POST', sprintf('/api/workout-generation-flow/%s/workout', $draft['id']));
+        self::assertResponseStatusCodeSame(201);
+        $secondWorkout = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame($firstWorkout['id'], $secondWorkout['id']);
+        self::assertSame('Regenerated WOD', $secondWorkout['name']);
+        $workoutGeneration = $this->getRepository(WorkoutGeneration::class)->find($draft['id']);
+        self::assertSame(1, $this->getRepository(Workout::class)->count(['workoutGeneration' => $workoutGeneration]));
     }
 
     public function testWorkoutGenerationMatchesCatalogFiltersByNameWhenCatalogRowsAreDuplicated(): void


### PR DESCRIPTION
## Summary
- update an existing generated workout when the same workout generation draft is generated again
- keep movement and implement relations in sync with the regenerated workout
- add workflow coverage for pressing generate twice on the same draft

## Tests
- php -l src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
- php -l tests/WorkoutApiWorkflowTest.php
- composer cs:check

Note: local WorkoutApiWorkflowTest could not connect to the local PostgreSQL test database; CI covers this integration test.