### PR TITLE
Expose workout generation prompt

### DIFF
--- a/migrations/Version20260519100000.php
+++ b/migrations/Version20260519100000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260519100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Store workout generation stimulus metadata.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE workout_generation ADD stimulus VARCHAR(120) DEFAULT NULL');
+        $this->addSql('ALTER TABLE workout_generation ADD stimulus_intent TEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE workout_generation DROP stimulus');
+        $this->addSql('ALTER TABLE workout_generation DROP stimulus_intent');
+    }
+}

--- a/src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
+++ b/src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
@@ -132,7 +132,8 @@ class WorkoutGenerationFlowController extends AbstractController
             ->setNumberOfRounds($generatedWorkout->getNumberOfRounds())
             ->setTimeCap($generatedWorkout->getTimeCap())
             ->setWorkoutType($generatedWorkout->getWorkoutType())
-            ->setWorkoutOrigin($generatedWorkout->getWorkoutOrigin());
+            ->setWorkoutOrigin($generatedWorkout->getWorkoutOrigin())
+            ->setGenerationPrompt($generatedWorkout->getGenerationPrompt());
 
         foreach ($existingWorkout->getImplements()->toArray() as $implement) {
             $existingWorkout->removeImplement($implement);
@@ -154,6 +155,12 @@ class WorkoutGenerationFlowController extends AbstractController
     {
         if (array_key_exists('name', $payload)) {
             $workoutGeneration->setName((string) $payload['name']);
+        }
+        if (array_key_exists('stimulus', $payload)) {
+            $workoutGeneration->setStimulus($this->nullableString($payload['stimulus'] ?? null, 120));
+        }
+        if (array_key_exists('stimulusIntent', $payload)) {
+            $workoutGeneration->setStimulusIntent($this->nullableString($payload['stimulusIntent'] ?? null));
         }
         if (array_key_exists('timeCap', $payload)) {
             $workoutGeneration->setTimeCap((int) $payload['timeCap']);
@@ -299,6 +306,20 @@ class WorkoutGenerationFlowController extends AbstractController
         }, $identifiers)));
     }
 
+    private function nullableString(mixed $value, ?int $maxLength = null): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+        if ($value === '') {
+            return null;
+        }
+
+        return $maxLength === null ? $value : substr($value, 0, $maxLength);
+    }
+
     /**
      * @param class-string<object> $className
      *
@@ -328,6 +349,8 @@ class WorkoutGenerationFlowController extends AbstractController
         return [
             'id' => $workoutGeneration->getId()?->toString(),
             'name' => $workoutGeneration->getName(),
+            'stimulus' => $workoutGeneration->getStimulus(),
+            'stimulusIntent' => $workoutGeneration->getStimulusIntent(),
             'timeCap' => $workoutGeneration->getTimeCap(),
             'workoutType' => $this->serializeCatalogEntity($workoutGeneration->getWorkoutType()),
             'movementGenerationType' => $this->serializeCatalogEntity($workoutGeneration->getMovementGenerationType()),
@@ -353,6 +376,7 @@ class WorkoutGenerationFlowController extends AbstractController
             'flow' => $workout->getFlow(),
             'timeCap' => $workout->getTimeCap(),
             'numberOfRounds' => $workout->getNumberOfRounds(),
+            'generationPrompt' => $workout->getGenerationPrompt(),
             'workoutType' => $workout->getWorkoutType() ? $this->serializeCatalogEntity($workout->getWorkoutType()) : null,
             'movements' => array_map($this->serializeMovement(...), $workout->getMovements()->toArray()),
             'implements' => array_map($this->serializeCatalogEntity(...), $workout->getImplements()->toArray()),

--- a/src/Entity/Workout/Workout.php
+++ b/src/Entity/Workout/Workout.php
@@ -76,6 +76,8 @@ class Workout
     #[ORM\OneToMany(mappedBy: 'workout', targetEntity: CompetitionEvent::class)]
     private Collection $competitionEvents;
 
+    private ?string $generationPrompt = null;
+
     public function __construct(
         ?string $name,
         string $flow,
@@ -238,6 +240,18 @@ class Workout
     public function getWorkoutGeneration(): ?WorkoutGeneration
     {
         return $this->workoutGeneration;
+    }
+
+    public function getGenerationPrompt(): ?string
+    {
+        return $this->generationPrompt;
+    }
+
+    public function setGenerationPrompt(?string $generationPrompt): static
+    {
+        $this->generationPrompt = $generationPrompt;
+
+        return $this;
     }
 
     /**

--- a/src/Entity/WorkoutGeneration/WorkoutGeneration.php
+++ b/src/Entity/WorkoutGeneration/WorkoutGeneration.php
@@ -73,6 +73,12 @@ class WorkoutGeneration
     #[ORM\Column(nullable: true)]
     private ?int $numberOfRounds;
 
+    #[ORM\Column(length: 120, nullable: true)]
+    private ?string $stimulus = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $stimulusIntent = null;
+
     public function __construct(
     ) {
         $this->movementTypes = new ArrayCollection();
@@ -315,6 +321,30 @@ class WorkoutGeneration
     public function setMovementGenerationType(WorkoutMovementGenerationType $movementGenerationType): WorkoutGeneration
     {
         $this->movementGenerationType = $movementGenerationType;
+
+        return $this;
+    }
+
+    public function getStimulus(): ?string
+    {
+        return $this->stimulus;
+    }
+
+    public function setStimulus(?string $stimulus): WorkoutGeneration
+    {
+        $this->stimulus = $stimulus;
+
+        return $this;
+    }
+
+    public function getStimulusIntent(): ?string
+    {
+        return $this->stimulusIntent;
+    }
+
+    public function setStimulusIntent(?string $stimulusIntent): WorkoutGeneration
+    {
+        $this->stimulusIntent = $stimulusIntent;
 
         return $this;
     }

--- a/src/Services/Workout/WorkoutCreatorService.php
+++ b/src/Services/Workout/WorkoutCreatorService.php
@@ -56,6 +56,16 @@ readonly class WorkoutCreatorService implements WorkoutCreatorServiceInterface
         \n possible implement1 (measure unit 1 : time of execution in milliseconds,measure unit 2 : time of execution in milliseconds,...,), 
         \n possible implement2 (measure unit 1 : time of execution in milliseconds,measure unit 2 : time of execution in milliseconds,...,), 
         \n ...)\n";
+        $promptForChatGPT .= sprintf("Workout name: %s\n", $workoutGeneration->getName());
+        if ($workoutGeneration->getStimulus() !== null) {
+            $promptForChatGPT .= sprintf("Workout stimulus identity: %s\n", $workoutGeneration->getStimulus());
+        }
+        if ($workoutGeneration->getStimulusIntent() !== null) {
+            $promptForChatGPT .= sprintf("Stimulus intent: %s\n", $workoutGeneration->getStimulusIntent());
+        }
+        $promptForChatGPT .= sprintf("Athlete level: %s\n", $workoutGeneration->getMovementDifficulty()->getName());
+        $promptForChatGPT .= sprintf("Team workout: %s\n", $workoutGeneration->isTeamWorkout() ? 'yes' : 'no');
+        $promptForChatGPT .= "Make the final workout flow match the stimulus identity and intent.\n";
         if ($workoutGeneration->getWorkoutType()->getNameAsEnum() === WorkoutTypeEnum::AMRAP) {
             $promptForChatGPT .= "This workout is an AMRAP, there is only one round to repeat as many rounds as possible in the time cap.\n";
         } elseif ($workoutGeneration->getWorkoutType()->getNameAsEnum() === WorkoutTypeEnum::FOR_TIME) {
@@ -193,6 +203,8 @@ readonly class WorkoutCreatorService implements WorkoutCreatorServiceInterface
             $workoutOrigin,
             $workoutGeneration->getAvailableImplements()->toArray(),
             $WorkoutMovements,
-        )->setWorkoutGeneration($workoutGeneration);
+        )
+            ->setWorkoutGeneration($workoutGeneration)
+            ->setGenerationPrompt($promptForChatGPT);
     }
 }

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -459,7 +459,9 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
                     new WorkoutOrigin(new WorkoutOriginName(WorkoutOriginNameEnum::CUSTOM), 2026),
                     $workoutGeneration->getAvailableImplements()->toArray(),
                     $workoutGeneration->getMandatoryMovements()->toArray(),
-                ))->setWorkoutGeneration($workoutGeneration);
+                ))
+                    ->setWorkoutGeneration($workoutGeneration)
+                    ->setGenerationPrompt('Prompt sent to OpenAI');
             }
         });
 
@@ -471,6 +473,8 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
             ['CONTENT_TYPE' => 'application/json'],
             json_encode([
                 'name' => 'Regenerated WOD',
+                'stimulus' => 'Engine long',
+                'stimulusIntent' => 'Volume soutenu, respiration stable, gestion du pacing.',
                 'timeCap' => 15,
                 'movementGenerationType' => 'selected movements',
                 'workoutType' => 'AMRAP',
@@ -500,7 +504,10 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
 
         self::assertSame($firstWorkout['id'], $secondWorkout['id']);
         self::assertSame('Regenerated WOD', $secondWorkout['name']);
+        self::assertSame('Prompt sent to OpenAI', $secondWorkout['generationPrompt']);
         $workoutGeneration = $this->getRepository(WorkoutGeneration::class)->find($draft['id']);
+        self::assertSame('Engine long', $workoutGeneration->getStimulus());
+        self::assertSame('Volume soutenu, respiration stable, gestion du pacing.', $workoutGeneration->getStimulusIntent());
         self::assertSame(1, $this->getRepository(Workout::class)->count(['workoutGeneration' => $workoutGeneration]));
     }
 


### PR DESCRIPTION
## Summary
- Store workout generation stimulus metadata on drafts
- Include stimulus identity, intent, level and team context in the OpenAI workout prompt
- Return the generated prompt in the workout generation response so the frontend can display it

## Tests
- composer cs:check
- php -l src/Entity/WorkoutGeneration/WorkoutGeneration.php
- php -l src/Entity/Workout/Workout.php
- php -l src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
- php -l src/Services/Workout/WorkoutCreatorService.php
- php -l migrations/Version20260519100000.php
- php -l tests/WorkoutApiWorkflowTest.php
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter testFrontendCanRegenerateWorkoutForTheSameDraft (fails locally: PostgreSQL connection refused)