### PR TITLE
Include no-equipment movements in generator filters

### DIFF
--- a/src/Repository/Workout/MovementRepository.php
+++ b/src/Repository/Workout/MovementRepository.php
@@ -68,8 +68,8 @@ class MovementRepository extends ServiceEntityRepository implements MovementRepo
 
         if (count($implements) > 0) {
             $query
-                ->join('m.possibleImplements', 'pi')
-                ->andWhere('pi.name IN (:implementNames)')
+                ->leftJoin('m.possibleImplements', 'pi')
+                ->andWhere('(pi.name IN (:implementNames) OR SIZE(m.possibleImplements) = 0)')
                 ->setParameter('implementNames', $this->entityNames($implements));
         }
 
@@ -80,6 +80,7 @@ class MovementRepository extends ServiceEntityRepository implements MovementRepo
         }
 
         return $query
+            ->distinct()
             ->getQuery()
             ->getResult();
     }
@@ -117,8 +118,8 @@ class MovementRepository extends ServiceEntityRepository implements MovementRepo
 
         if (count($implements) > 0) {
             $query
-                ->join('m.possibleImplements', 'pi')
-                ->andWhere('pi.name IN (:implementNames)')
+                ->leftJoin('m.possibleImplements', 'pi')
+                ->andWhere('(pi.name IN (:implementNames) OR SIZE(m.possibleImplements) = 0)')
                 ->setParameter('implementNames', $this->entityNames($implements));
         }
 
@@ -138,6 +139,7 @@ class MovementRepository extends ServiceEntityRepository implements MovementRepo
         }
 
         return $query
+            ->distinct()
             ->getQuery()
             ->getResult();
     }

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -561,5 +561,6 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
         $movementNames = array_column($payload['movements'], 'name');
 
         self::assertContains('Deadlift', $movementNames);
+        self::assertContains('Run', $movementNames);
     }
 }


### PR DESCRIPTION
## Summary
- Keep movements without implements available when the generator filters by selected equipment
- Add a regression assertion that Run appears in filtered possible movements

## Why
Run exists in the catalog, but it has no implement. The previous inner join on possible implements excluded it whenever the user selected equipment, which made Hyrox-style workouts miss running.

## Tests
- php -l src/Repository/Workout/MovementRepository.php
- php -l tests/WorkoutApiWorkflowTest.php
- composer cs:check
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter testWorkoutGenerationMatchesCatalogFiltersByNameWhenCatalogRowsAreDuplicated (fails locally: PostgreSQL connection refused)