### PR TITLE
Restrict workout generation prompt to admins

### DIFF
--- a/src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
+++ b/src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
@@ -370,17 +370,22 @@ class WorkoutGenerationFlowController extends AbstractController
 
     private function serializeWorkout(Workout $workout): array
     {
-        return [
+        $payload = [
             'id' => $workout->getId()?->toString(),
             'name' => $workout->getName(),
             'flow' => $workout->getFlow(),
             'timeCap' => $workout->getTimeCap(),
             'numberOfRounds' => $workout->getNumberOfRounds(),
-            'generationPrompt' => $workout->getGenerationPrompt(),
             'workoutType' => $workout->getWorkoutType() ? $this->serializeCatalogEntity($workout->getWorkoutType()) : null,
             'movements' => array_map($this->serializeMovement(...), $workout->getMovements()->toArray()),
             'implements' => array_map($this->serializeCatalogEntity(...), $workout->getImplements()->toArray()),
         ];
+
+        if ($this->isGranted('ROLE_ADMIN')) {
+            $payload['generationPrompt'] = $workout->getGenerationPrompt();
+        }
+
+        return $payload;
     }
 
     private function serializeCatalogEntity(object $entity): array

--- a/tests/WorkoutApiWorkflowTest.php
+++ b/tests/WorkoutApiWorkflowTest.php
@@ -11,6 +11,7 @@ use App\Entity\Competition\CompetitionEvent;
 use App\Entity\Competition\Enum\ScoreTypeEnum;
 use App\Entity\Competition\Score;
 use App\Entity\Competition\WorkoutResult;
+use App\Entity\Security\User;
 use App\Entity\Workout\BodyPart;
 use App\Entity\Workout\Enum\BodyPartEnum;
 use App\Entity\Workout\Enum\ImplementEnum;
@@ -504,11 +505,25 @@ class WorkoutApiWorkflowTest extends AbstractIntegrationTest
 
         self::assertSame($firstWorkout['id'], $secondWorkout['id']);
         self::assertSame('Regenerated WOD', $secondWorkout['name']);
-        self::assertSame('Prompt sent to OpenAI', $secondWorkout['generationPrompt']);
+        self::assertArrayNotHasKey('generationPrompt', $secondWorkout);
         $workoutGeneration = $this->getRepository(WorkoutGeneration::class)->find($draft['id']);
         self::assertSame('Engine long', $workoutGeneration->getStimulus());
         self::assertSame('Volume soutenu, respiration stable, gestion du pacing.', $workoutGeneration->getStimulusIntent());
         self::assertSame(1, $this->getRepository(Workout::class)->count(['workoutGeneration' => $workoutGeneration]));
+
+        $admin = (new User('workout-admin@example.com'))
+            ->setPassword('test-password')
+            ->setRoles(['ROLE_ADMIN']);
+        $this->getEntityManager()->persist($admin);
+        $this->getEntityManager()->flush();
+
+        $this->browser()->loginUser($admin);
+        $this->browser()->request('POST', sprintf('/api/workout-generation-flow/%s/workout', $draft['id']));
+        self::assertResponseStatusCodeSame(201);
+        $adminWorkout = json_decode($this->browser()->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame($firstWorkout['id'], $adminWorkout['id']);
+        self::assertSame('Prompt sent to OpenAI', $adminWorkout['generationPrompt']);
     }
 
     public function testWorkoutGenerationMatchesCatalogFiltersByNameWhenCatalogRowsAreDuplicated(): void


### PR DESCRIPTION
## Summary
- Return the workout generation prompt only when the current user has ROLE_ADMIN
- Keep the generated workout payload clean for anonymous and non-admin users
- Update the regeneration workflow test to cover non-admin and admin responses

## Related
- Created issue #142 for the empirical loading and scaling database from competition workouts

## Tests
- php -l src/Controller/WorkoutGeneration/WorkoutGenerationFlowController.php
- php -l tests/WorkoutApiWorkflowTest.php
- composer cs:check
- composer psalm
- git diff --check
- php -d memory_limit=1G bin/phpunit --colors=always --filter testFrontendCanRegenerateWorkoutForTheSameDraft (fails locally: test database host db is unavailable outside Docker/CI)