### PR TITLE
Add workout loading and scaling prompt guidance

### DIFF
--- a/src/Services/Workout/WorkoutCreatorService.php
+++ b/src/Services/Workout/WorkoutCreatorService.php
@@ -70,6 +70,13 @@ readonly class WorkoutCreatorService implements WorkoutCreatorServiceInterface
         $promptForChatGPT .= sprintf("Athlete level: %s\n", $workoutGeneration->getMovementDifficulty()->getName());
         $promptForChatGPT .= sprintf("Team workout: %s\n", $workoutGeneration->isTeamWorkout() ? 'yes' : 'no');
         $promptForChatGPT .= "Make the final workout flow match the stimulus identity and intent.\n";
+        $promptForChatGPT .= $this->levelPrescriptionGuidance($workoutGeneration);
+        $promptForChatGPT .= <<<EOD
+When prescribing loaded movements, always include level-appropriate male/female loads in kg when relevant. Use heavier and more technical prescriptions for Elite, standard competitive prescriptions for RX, sustainable prescriptions for Intermediate, and accessible prescriptions for Scaled/Beginner.
+Add a short "Scaling options" section at the end of the flow with practical adaptations for RX, Intermediate and Scaled athletes. Preserve the intended stimulus when scaling: change load, range of motion, movement complexity, reps or distance before changing the workout goal.
+For high-skill movements, suggest realistic substitutions by level, for example strict HSPU may scale to kipping HSPU, pike HSPU, dumbbell press or hand-release push-ups depending on the level.
+
+EOD;
         if ($workoutGeneration->getWorkoutType()->getNameAsEnum() === WorkoutTypeEnum::AMRAP) {
             $promptForChatGPT .= "This workout is an AMRAP, there is only one round to repeat as many rounds as possible in the time cap.\n";
         } elseif ($workoutGeneration->getWorkoutType()->getNameAsEnum() === WorkoutTypeEnum::FOR_TIME) {
@@ -254,6 +261,17 @@ EOD;
         }
 
         return $prompt;
+    }
+
+    private function levelPrescriptionGuidance(WorkoutGeneration $workoutGeneration): string
+    {
+        return match ($workoutGeneration->getMovementDifficulty()->getName()) {
+            'Elite' => "Level prescription guidance: create an Elite version with demanding loads, advanced gymnastics where appropriate, and competitive volume. Do not downscale the main workout for accessibility, but still include scaling options below it.\n",
+            'RX' => "Level prescription guidance: create an RX version with standard box competition loads and skills. Avoid Elite-only loading unless the stimulus explicitly calls for it.\n",
+            'Intermediate' => "Level prescription guidance: create an Intermediate version with moderate loads, manageable skill choices, and repeatable pacing while keeping the intended stimulus.\n",
+            'Beginner' => "Level prescription guidance: create a Scaled/Beginner version with accessible loads, simple movement patterns, and lower technical barriers while keeping the intended stimulus.\n",
+            default => sprintf("Level prescription guidance: adapt loads, skills and volume to the requested level \"%s\" while keeping the intended stimulus.\n", $workoutGeneration->getMovementDifficulty()->getName()),
+        };
     }
 
     /**

--- a/tests/WorkoutCreatorServiceTest.php
+++ b/tests/WorkoutCreatorServiceTest.php
@@ -111,6 +111,9 @@ class WorkoutCreatorServiceTest extends TestCase
         self::assertStringContainsString('- Run', $chatGpt->prompt);
         self::assertStringContainsString('- Row', $chatGpt->prompt);
         self::assertStringContainsString('- Burpee', $chatGpt->prompt);
+        self::assertStringContainsString('Level prescription guidance: create an Intermediate version', $chatGpt->prompt);
+        self::assertStringContainsString('always include level-appropriate male/female loads in kg', $chatGpt->prompt);
+        self::assertStringContainsString('Scaling options', $chatGpt->prompt);
         self::assertSame(['Run', 'Burpee'], array_map(
             static fn (Movement $movement): ?string => $movement->getName(),
             $workout->getMovements()->toArray()


### PR DESCRIPTION
## Summary
- Add level-specific prescription guidance to workout generation prompts
- Ask OpenAI to prescribe level-appropriate male/female loads in kg for loaded movements
- Ask generated WODs to include a short Scaling options section for RX, Intermediate and Scaled athletes
- Cover the prompt additions in WorkoutCreatorServiceTest

## Tests
- php -l src/Services/Workout/WorkoutCreatorService.php
- php -l tests/WorkoutCreatorServiceTest.php
- php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutCreatorServiceTest
- composer cs:check
- composer psalm
- git diff --check