### PR TITLE
Enforce workout scaling and team guidance

### DIFF
--- a/src/Services/Workout/WorkoutCreatorService.php
+++ b/src/Services/Workout/WorkoutCreatorService.php
@@ -69,12 +69,14 @@ readonly class WorkoutCreatorService implements WorkoutCreatorServiceInterface
         }
         $promptForChatGPT .= sprintf("Athlete level: %s\n", $workoutGeneration->getMovementDifficulty()->getName());
         $promptForChatGPT .= sprintf("Team workout: %s\n", $workoutGeneration->isTeamWorkout() ? 'yes' : 'no');
+        $promptForChatGPT .= $this->teamWorkoutGuidance($workoutGeneration);
         $promptForChatGPT .= "Make the final workout flow match the stimulus identity and intent.\n";
         $promptForChatGPT .= $this->levelPrescriptionGuidance($workoutGeneration);
         $promptForChatGPT .= <<<EOD
 When prescribing loaded movements, always include level-appropriate male/female loads in kg when relevant. Use heavier and more technical prescriptions for Elite, standard competitive prescriptions for RX, sustainable prescriptions for Intermediate, and accessible prescriptions for Scaled/Beginner.
 Add a short "Scaling options" section at the end of the flow with practical adaptations for RX, Intermediate and Scaled athletes. Preserve the intended stimulus when scaling: change load, range of motion, movement complexity, reps or distance before changing the workout goal.
 For high-skill movements, suggest realistic substitutions by level, for example strict HSPU may scale to kipping HSPU, pike HSPU, dumbbell press or hand-release push-ups depending on the level.
+The Scaling options section is mandatory. Also return it separately in the JSON "scalingOptions" field.
 
 EOD;
         if ($workoutGeneration->getWorkoutType()->getNameAsEnum() === WorkoutTypeEnum::AMRAP) {
@@ -201,14 +203,15 @@ EOD;
 Return only valid JSON, with no markdown and no explanation, using this exact shape:
 {
   "flow": "The complete workout text displayed to the athlete",
+  "scalingOptions": "A short Scaling options section with RX, Intermediate and Scaled adaptations",
   "movements": ["Exact movement name from the allowed lists"]
 }
-The movements array must contain the exact selected movement names used in the flow.
+The flow should include the scaling options at the end. The movements array must contain the exact selected movement names used in the flow.
 EOD;
 
         $rawResponse = $this->chatGPTApiKey->getWorkoutFlowFromPrompt($promptForChatGPT);
         $generatedWorkout = $this->parseGeneratedWorkout($rawResponse);
-        $flow = $generatedWorkout['flow'];
+        $flow = $this->flowWithScalingOptions($generatedWorkout['flow'], $generatedWorkout['scalingOptions']);
         $WorkoutMovements = $this->resolveSelectedMovements(
             $generatedWorkout['movements'],
             $mandatoryMovements,
@@ -274,8 +277,20 @@ EOD;
         };
     }
 
+    private function teamWorkoutGuidance(WorkoutGeneration $workoutGeneration): string
+    {
+        if (!$workoutGeneration->isTeamWorkout()) {
+            return "Team workout guidance: this is an individual workout. Do not use partner relay, shared reps or synchronized work.\n";
+        }
+
+        return <<<TXT
+Team workout guidance: this must be explicitly written as a team workout. Use team-of-2 unless another team size is clearly better for the stimulus. Include a clear work-sharing pattern such as "you go, I go", shared reps, split anyhow, synchronized reps, relay stations or partner alternating rounds. The flow must make the team structure impossible to miss.
+
+TXT;
+    }
+
     /**
-     * @return array{flow: string, movements: list<string>}
+     * @return array{flow: string, scalingOptions: string, movements: list<string>}
      */
     private function parseGeneratedWorkout(string $rawResponse): array
     {
@@ -298,18 +313,29 @@ EOD;
         }
 
         $flow = trim((string) ($payload['flow'] ?? ''));
+        $scalingOptions = trim((string) ($payload['scalingOptions'] ?? ''));
         $movements = $payload['movements'] ?? [];
-        if ($flow === '' || !is_array($movements)) {
+        if ($flow === '' || $scalingOptions === '' || !is_array($movements)) {
             throw new \RuntimeException('OpenAI workout generation returned an invalid workout payload.');
         }
 
         return [
             'flow' => $flow,
+            'scalingOptions' => $scalingOptions,
             'movements' => array_values(array_filter(array_map(
                 static fn (mixed $movement): ?string => is_string($movement) && trim($movement) !== '' ? trim($movement) : null,
                 $movements
             ))),
         ];
+    }
+
+    private function flowWithScalingOptions(string $flow, string $scalingOptions): string
+    {
+        if (str_contains(strtolower($flow), 'scaling options')) {
+            return $flow;
+        }
+
+        return rtrim($flow)."\n\nScaling options:\n".trim($scalingOptions);
     }
 
     /**

--- a/tests/WorkoutCreatorServiceTest.php
+++ b/tests/WorkoutCreatorServiceTest.php
@@ -80,6 +80,7 @@ class WorkoutCreatorServiceTest extends TestCase
 
                 return json_encode([
                     'flow' => "For time:\n1000 m Run\n50 Burpees",
+                    'scalingOptions' => "RX: as written\nIntermediate: 800 m Run and 35 Burpees\nScaled: 600 m Run and 25 Burpees",
                     'movements' => ['Run', 'Burpee'],
                 ], JSON_THROW_ON_ERROR);
             }
@@ -114,9 +115,99 @@ class WorkoutCreatorServiceTest extends TestCase
         self::assertStringContainsString('Level prescription guidance: create an Intermediate version', $chatGpt->prompt);
         self::assertStringContainsString('always include level-appropriate male/female loads in kg', $chatGpt->prompt);
         self::assertStringContainsString('Scaling options', $chatGpt->prompt);
+        self::assertStringContainsString('"scalingOptions"', $chatGpt->prompt);
+        self::assertStringContainsString('Team workout guidance: this is an individual workout', $chatGpt->prompt);
+        self::assertStringContainsString("Scaling options:\nRX: as written", $workout->getFlow());
         self::assertSame(['Run', 'Burpee'], array_map(
             static fn (Movement $movement): ?string => $movement->getName(),
             $workout->getMovements()->toArray()
         ));
+    }
+
+    public function testTeamWorkoutPromptRequiresExplicitTeamStructure(): void
+    {
+        $difficulty = new MovementDifficulty(MovementDifficultyEnum::RX);
+        $cardio = new MovementType(MovementTypeEnum::CARDIO);
+        $run = new Movement('Run', $difficulty, $cardio);
+        $row = new Movement('Row', $difficulty, $cardio);
+
+        $movementService = new class([$run, $row]) implements MovementServiceInterface {
+            /**
+             * @param list<Movement> $possibleMovements
+             */
+            public function __construct(private readonly array $possibleMovements)
+            {
+            }
+
+            public function getWorkoutMovementsFromWorkoutGeneration(WorkoutGeneration $workoutGeneration): array
+            {
+                return [];
+            }
+
+            public function getPossibleWorkoutMovementsFromWorkoutGeneration(WorkoutGeneration $workoutGeneration): array
+            {
+                return $this->possibleMovements;
+            }
+
+            public function removeNotAvailableImplementsFromMovementsOfWorkout(Collection $possibleImplements, array $movements): array
+            {
+                return $movements;
+            }
+
+            public function getMovementsFromMuscles(WorkoutGeneration $workoutGeneration): array
+            {
+                return [];
+            }
+
+            public function getPossibleMovementsFromMuscles(WorkoutGeneration $workoutGeneration): array
+            {
+                return [];
+            }
+
+            public function getWorkoutMovementsFromPossibleMovements(array $possibleMovements, WorkoutGeneration $workoutGeneration): array
+            {
+                return [];
+            }
+        };
+
+        $chatGpt = new class implements ChatGPTApiKeyInterface {
+            public string $prompt = '';
+
+            public function getWorkoutFlowFromPrompt(string $prompt): string
+            {
+                $this->prompt = $prompt;
+
+                return json_encode([
+                    'flow' => "Team of 2, for time:\nYou go, I go rounds\n400 m Run\n500 m Row",
+                    'scalingOptions' => "RX: as written\nIntermediate: reduce row pace\nScaled: 250 m Run and 350 m Row",
+                    'movements' => ['Run', 'Row'],
+                ], JSON_THROW_ON_ERROR);
+            }
+        };
+
+        $workoutOriginService = new class implements WorkoutOriginServiceInterface {
+            public function getExistingOrInsertNewWorkoutOrigin(string $name, int $year): WorkoutOrigin
+            {
+                return new WorkoutOrigin(new WorkoutOriginName(WorkoutOriginNameEnum::CUSTOM), $year);
+            }
+        };
+
+        $workoutGeneration = (new WorkoutGeneration())
+            ->setName('Team engine test')
+            ->setTimeCap(24)
+            ->setWorkoutType(new WorkoutType(WorkoutTypeEnum::FOR_TIME))
+            ->setMovementGenerationType(new WorkoutMovementGenerationType(WorkoutMovementGenerationTypeEnum::MOVEMENT))
+            ->setMovementDifficulty($difficulty)
+            ->setMovementTypes([$cardio])
+            ->setNumberOfDifferentMovements(2)
+            ->setNumberOfRounds(4)
+            ->setIsTeamWorkout(true);
+
+        (new WorkoutCreatorService($movementService, $chatGpt, $workoutOriginService))->createWorkout($workoutGeneration);
+
+        self::assertStringContainsString('Team workout: yes', $chatGpt->prompt);
+        self::assertStringContainsString('this must be explicitly written as a team workout', $chatGpt->prompt);
+        self::assertStringContainsString('team-of-2', $chatGpt->prompt);
+        self::assertStringContainsString('you go, I go', $chatGpt->prompt);
     }
 }


### PR DESCRIPTION
## Summary
- Require OpenAI to return a separate scalingOptions field for generated workouts
- Append Scaling options to the flow server-side when the model omits the section in flow
- Strengthen team workout guidance so team WODs must include an explicit team structure
- Add unit coverage for mandatory scaling options and team workout prompting

## Frontend
No frontend change required: the generated flow is already rendered fully in the workout generator panel.

## Tests
- php -l src/Services/Workout/WorkoutCreatorService.php
- php -l tests/WorkoutCreatorServiceTest.php
- php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutCreatorServiceTest
- composer cs:check
- composer psalm
- git diff --check