### PR TITLE
Infer workout prescription patterns

### DIFF
--- a/src/Command/InferWorkoutPrescriptionPatternsCommand.php
+++ b/src/Command/InferWorkoutPrescriptionPatternsCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Workout\Workout;
+use App\Services\Workout\Prescription\WorkoutLoadMention;
+use App\Services\Workout\Prescription\WorkoutPrescriptionPatternInferer;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:workouts:infer-prescription-patterns',
+    description: 'Inspect imported workouts and report load/level signals that could feed generation scaling.'
+)]
+final class InferWorkoutPrescriptionPatternsCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly WorkoutPrescriptionPatternInferer $inferer,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('name', null, InputOption::VALUE_REQUIRED, 'Restrict the scan to one workout name.')
+            ->addOption('source', null, InputOption::VALUE_REQUIRED, 'Restrict the scan to one source name.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum number of workouts to scan.', 50)
+            ->addOption('with-signal-only', null, InputOption::VALUE_NONE, 'Only display workouts with detected loads or level hints.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $limit = max(1, (int) $input->getOption('limit'));
+        $name = $this->stringOption($input->getOption('name'));
+        $source = $this->stringOption($input->getOption('source'));
+        $withSignalOnly = (bool) $input->getOption('with-signal-only');
+
+        $workouts = $this->workouts($name, $source, $limit);
+        $rows = [];
+        $scanned = 0;
+        $withLoads = 0;
+        $withLevelHints = 0;
+
+        foreach ($workouts as $workout) {
+            ++$scanned;
+            $prescription = $this->inferer->infer($workout);
+
+            if ($prescription->loads !== []) {
+                ++$withLoads;
+            }
+            if ($prescription->levelHints !== []) {
+                ++$withLevelHints;
+            }
+            if ($withSignalOnly && !$prescription->hasActionableSignal()) {
+                continue;
+            }
+
+            $rows[] = [
+                $workout->getName() ?? '-',
+                $workout->getSourceName() ?? '-',
+                $workout->getExternalId() ?? '-',
+                $this->listLabel($prescription->levelHints),
+                $this->listLabel($prescription->divisionHints, 4),
+                $this->listLabel($prescription->movementNames, 4),
+                $this->listLabel(array_map(static fn (WorkoutLoadMention $load): string => $load->label(), $prescription->loads), 5),
+                $this->flowPreview($workout),
+            ];
+        }
+
+        $io->title('Workout prescription pattern report');
+        $io->definitionList(
+            ['scanned' => $scanned],
+            ['with_loads' => $withLoads],
+            ['with_level_hints' => $withLevelHints],
+        );
+
+        if ($rows !== []) {
+            $table = new Table($output);
+            $table
+                ->setHeaders(['Workout', 'Source', 'External ID', 'Levels', 'Divisions', 'Movements', 'Loads', 'Flow preview'])
+                ->setRows($rows);
+            $table->render();
+        } else {
+            $io->note('No workout matched the current display filters.');
+        }
+
+        $io->note('Report only. No data was written.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<Workout>
+     */
+    private function workouts(?string $name, ?string $source, int $limit): array
+    {
+        $queryBuilder = $this->entityManager->getRepository(Workout::class)
+            ->createQueryBuilder('workout')
+            ->orderBy('workout.createdAt', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($name !== null) {
+            $queryBuilder
+                ->andWhere('LOWER(workout.name) LIKE LOWER(:name)')
+                ->setParameter('name', '%'.$name.'%');
+        }
+
+        if ($source !== null) {
+            $queryBuilder
+                ->andWhere('workout.sourceName = :source')
+                ->setParameter('source', $source);
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+
+    private function stringOption(mixed $value): ?string
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        return trim($value);
+    }
+
+    /**
+     * @param list<string> $values
+     */
+    private function listLabel(array $values, int $max = 3): string
+    {
+        if ($values === []) {
+            return '-';
+        }
+
+        $shown = array_slice($values, 0, $max);
+        $extra = count($values) - count($shown);
+
+        return implode(', ', $shown).($extra > 0 ? sprintf(' +%d', $extra) : '');
+    }
+
+    private function flowPreview(Workout $workout): string
+    {
+        $preview = trim((string) preg_replace('/\s+/', ' ', $workout->getFlow()));
+
+        if (strlen($preview) <= 100) {
+            return $preview;
+        }
+
+        return substr($preview, 0, 97).'...';
+    }
+}

--- a/src/Services/Workout/Prescription/InferredWorkoutPrescription.php
+++ b/src/Services/Workout/Prescription/InferredWorkoutPrescription.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services\Workout\Prescription;
+
+final readonly class InferredWorkoutPrescription
+{
+    /**
+     * @param list<string>             $divisionHints
+     * @param list<string>             $levelHints
+     * @param list<string>             $movementNames
+     * @param list<string>             $implementNames
+     * @param list<WorkoutLoadMention> $loads
+     */
+    public function __construct(
+        public array $divisionHints,
+        public array $levelHints,
+        public array $movementNames,
+        public array $implementNames,
+        public array $loads,
+    ) {
+    }
+
+    public function hasActionableSignal(): bool
+    {
+        return $this->loads !== [] || $this->levelHints !== [];
+    }
+}

--- a/src/Services/Workout/Prescription/WorkoutLoadMention.php
+++ b/src/Services/Workout/Prescription/WorkoutLoadMention.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services\Workout\Prescription;
+
+final readonly class WorkoutLoadMention
+{
+    /**
+     * @param list<float> $values
+     */
+    public function __construct(
+        public string $raw,
+        public array $values,
+        public string $unit,
+        public string $equipmentHint,
+    ) {
+    }
+
+    public function label(): string
+    {
+        $values = implode('/', array_map(static function (float $value): string {
+            return rtrim(rtrim(sprintf('%.2F', $value), '0'), '.');
+        }, $this->values));
+
+        $equipment = $this->equipmentHint === 'unknown' ? '' : ' '.$this->equipmentHint;
+
+        return sprintf('%s %s%s', $values, $this->unit, $equipment);
+    }
+}

--- a/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
+++ b/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace App\Services\Workout\Prescription;
+
+use App\Entity\Workout\Implement;
+use App\Entity\Workout\Movement;
+use App\Entity\Workout\Workout;
+
+final class WorkoutPrescriptionPatternInferer
+{
+    private const LOAD_PATTERN = '/(?<![a-z0-9])(?P<first>\d+(?:[\.,]\d+)?)\s*(?:\/|and|or|&)\s*(?P<second>\d+(?:[\.,]\d+)?)\s*(?P<unit>kg|kgs|kilograms?|lb|lbs|pounds?)(?![a-z])/i';
+    private const SINGLE_LOAD_PATTERN = '/(?<![a-z0-9])(?:(?P<count>\d+)\s*x\s*)?(?P<value>\d+(?:[\.,]\d+)?)\s*-?\s*(?P<unit>kg|kgs|kilograms?|lb|lbs|pounds?)(?![a-z])/i';
+
+    public function infer(Workout $workout): InferredWorkoutPrescription
+    {
+        $divisionHints = $this->divisionHints($workout);
+        $text = implode("\n", array_filter([
+            $workout->getName(),
+            $workout->getFlow(),
+            implode("\n", $divisionHints),
+        ]));
+
+        return new InferredWorkoutPrescription(
+            $divisionHints,
+            $this->levelHints($text),
+            $this->movementNames($workout),
+            $this->implementNames($workout),
+            $this->loads($text),
+        );
+    }
+
+    /**
+     * @return list<WorkoutLoadMention>
+     */
+    private function loads(string $text): array
+    {
+        $loads = [];
+        $seen = [];
+
+        if (preg_match_all(self::LOAD_PATTERN, $text, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
+            foreach ($matches as $match) {
+                $raw = $match[0][0];
+                $load = new WorkoutLoadMention(
+                    $raw,
+                    [$this->floatValue($match['first'][0]), $this->floatValue($match['second'][0])],
+                    $this->unit($match['unit'][0]),
+                    $this->equipmentHint($text, (int) $match[0][1], strlen($raw)),
+                );
+                $this->addLoad($loads, $seen, $load);
+            }
+        }
+
+        if (preg_match_all(self::SINGLE_LOAD_PATTERN, $text, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
+            foreach ($matches as $match) {
+                $raw = $match[0][0];
+                $offset = (int) $match[0][1];
+
+                if ($this->isPartOfPairedLoad($text, $offset, strlen($raw))) {
+                    continue;
+                }
+
+                $values = [$this->floatValue($match['value'][0])];
+                if (isset($match['count'][0]) && $match['count'][0] !== '') {
+                    $values = array_fill(0, (int) $match['count'][0], $values[0]);
+                }
+
+                $load = new WorkoutLoadMention(
+                    $raw,
+                    $values,
+                    $this->unit($match['unit'][0]),
+                    $this->equipmentHint($text, $offset, strlen($raw)),
+                );
+                $this->addLoad($loads, $seen, $load);
+            }
+        }
+
+        return $loads;
+    }
+
+    /**
+     * @param list<WorkoutLoadMention> $loads
+     * @param array<string, true>      $seen
+     */
+    private function addLoad(array &$loads, array &$seen, WorkoutLoadMention $load): void
+    {
+        $key = strtolower($load->raw.'|'.$load->equipmentHint);
+        if (isset($seen[$key])) {
+            return;
+        }
+
+        $loads[] = $load;
+        $seen[$key] = true;
+    }
+
+    private function isPartOfPairedLoad(string $text, int $offset, int $length): bool
+    {
+        $before = substr($text, max(0, $offset - 8), 8);
+        $after = substr($text, $offset + $length, 8);
+
+        return str_contains($before, '/') || str_contains($after, '/');
+    }
+
+    private function equipmentHint(string $text, int $offset, int $length): string
+    {
+        $windowStart = max(0, $offset - 48);
+        $window = strtolower(substr($text, $windowStart, $length + 96));
+        $loadCenter = $offset - $windowStart + (int) floor($length / 2);
+
+        $hints = [
+            'dumbbell' => ['dumbbell', 'dumbbells', 'db'],
+            'kettlebell' => ['kettlebell', 'kettlebells', 'kb'],
+            'barbell' => ['barbell', 'clean', 'snatch', 'deadlift', 'thruster', 'squat', 'jerk'],
+            'medicine ball' => ['medicine ball', 'wall ball'],
+            'sandbag' => ['sandbag'],
+            'sled' => ['sled'],
+            'vest' => ['vest', 'ruck'],
+        ];
+        $closestHint = null;
+        $closestDistance = PHP_INT_MAX;
+
+        foreach ($hints as $hint => $terms) {
+            foreach ($terms as $term) {
+                $position = strpos($window, $term);
+                while ($position !== false) {
+                    $distance = abs(($position + (int) floor(strlen($term) / 2)) - $loadCenter);
+                    if ($distance < $closestDistance) {
+                        $closestHint = $hint;
+                        $closestDistance = $distance;
+                    }
+                    $position = strpos($window, $term, $position + 1);
+                }
+            }
+        }
+
+        return $closestHint ?? 'unknown';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function levelHints(string $text): array
+    {
+        $levels = [
+            'elite' => '/\belite\b/i',
+            'rx' => '/\brx(?:d|\'d)?\b/i',
+            'intermediate' => '/\b(?:intermediate|inter)\b/i',
+            'scaled' => '/\bscaled\b/i',
+            'beginner' => '/\b(?:beginner|beginners?|rookie)\b/i',
+            'masters' => '/\bmasters?\b/i',
+            'teen' => '/\bteens?\b/i',
+        ];
+        $matches = [];
+
+        foreach ($levels as $level => $pattern) {
+            if (preg_match($pattern, $text) === 1) {
+                $matches[] = $level;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function divisionHints(Workout $workout): array
+    {
+        $divisions = [];
+        foreach ($workout->getCompetitionContexts() as $context) {
+            foreach ($context['divisions'] as $division) {
+                $divisions[$division] = true;
+            }
+        }
+
+        $divisionNames = array_keys($divisions);
+        sort($divisionNames, SORT_NATURAL | SORT_FLAG_CASE);
+
+        return $divisionNames;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function movementNames(Workout $workout): array
+    {
+        $names = array_filter(array_map(
+            static fn (Movement $movement): ?string => $movement->getName(),
+            $workout->getMovements()->toArray(),
+        ));
+        sort($names, SORT_NATURAL | SORT_FLAG_CASE);
+
+        return array_values($names);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function implementNames(Workout $workout): array
+    {
+        $names = array_map(
+            static fn (Implement $implement): string => $implement->getName(),
+            $workout->getImplements()->toArray(),
+        );
+        sort($names, SORT_NATURAL | SORT_FLAG_CASE);
+
+        return array_values($names);
+    }
+
+    private function unit(string $unit): string
+    {
+        $unit = strtolower($unit);
+
+        return str_starts_with($unit, 'k') ? 'kg' : 'lb';
+    }
+
+    private function floatValue(string $value): float
+    {
+        return (float) str_replace(',', '.', $value);
+    }
+}

--- a/tests/WorkoutPrescriptionPatternInfererTest.php
+++ b/tests/WorkoutPrescriptionPatternInfererTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Workout\Enum\WorkoutOriginNameEnum;
+use App\Entity\Workout\Workout;
+use App\Entity\Workout\WorkoutOrigin;
+use App\Entity\Workout\WorkoutOriginName;
+use App\Services\Workout\Prescription\WorkoutPrescriptionPatternInferer;
+use PHPUnit\Framework\TestCase;
+
+final class WorkoutPrescriptionPatternInfererTest extends TestCase
+{
+    public function testInfersPairedBarbellLoadsAndLevelHints(): void
+    {
+        $workout = $this->workout(
+            'Elite/RX event',
+            'For time: 21-15-9 thrusters at 135/95 lb and chest-to-bar pull-ups. Elite athletes use RX loading.'
+        );
+
+        $prescription = (new WorkoutPrescriptionPatternInferer())->infer($workout);
+
+        self::assertSame(['elite', 'rx'], $prescription->levelHints);
+        self::assertCount(1, $prescription->loads);
+        self::assertSame([135.0, 95.0], $prescription->loads[0]->values);
+        self::assertSame('lb', $prescription->loads[0]->unit);
+        self::assertSame('barbell', $prescription->loads[0]->equipmentHint);
+    }
+
+    public function testInfersSingleDumbbellAndRepeatedKettlebellLoads(): void
+    {
+        $workout = $this->workout(
+            'Scaled team event',
+            'AMRAP with 50-lb dumbbell snatches, then 2 x 24 kg kettlebell front-rack walking lunges. Scaled pairs split reps.'
+        );
+
+        $prescription = (new WorkoutPrescriptionPatternInferer())->infer($workout);
+
+        self::assertSame(['scaled'], $prescription->levelHints);
+        self::assertCount(2, $prescription->loads);
+        self::assertSame('50 lb dumbbell', $prescription->loads[0]->label());
+        self::assertSame('24/24 kg kettlebell', $prescription->loads[1]->label());
+    }
+
+    private function workout(string $name, string $flow): Workout
+    {
+        return new Workout(
+            $name,
+            $flow,
+            null,
+            null,
+            null,
+            new WorkoutOrigin(new WorkoutOriginName(WorkoutOriginNameEnum::OTHER), null),
+        );
+    }
+}


### PR DESCRIPTION
Summary:
- add a read-only workout prescription inferer for load, equipment, division, and level hints
- add an admin/console report command to inspect imported workouts before designing persisted scaling data
- cover paired and single load detection with unit tests

Validation:
- php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutPrescriptionPatternInfererTest
- composer cs:check
- composer psalm
- php bin/console list app:workouts --env=test

Server smoke command after deploy:
php bin/console app:workouts:infer-prescription-patterns --source=crossfit_games --limit=50 --with-signal-only --env=prod