### PR TITLE
Group workout load candidates

### DIFF
--- a/src/Command/InferWorkoutPrescriptionPatternsCommand.php
+++ b/src/Command/InferWorkoutPrescriptionPatternsCommand.php
@@ -6,6 +6,7 @@ use App\Entity\Workout\Implement;
 use App\Entity\Workout\Movement;
 use App\Entity\Workout\Workout;
 use App\Services\Workout\Enrichment\WorkoutEnrichmentMatcher;
+use App\Services\Workout\Prescription\WorkoutLoadCandidate;
 use App\Services\Workout\Prescription\WorkoutLoadMention;
 use App\Services\Workout\Prescription\WorkoutPrescriptionPatternInferer;
 use Doctrine\ORM\EntityManagerInterface;
@@ -104,6 +105,7 @@ final class InferWorkoutPrescriptionPatternsCommand extends Command
                 $this->listLabel($movementNames, 4),
                 $this->listLabel($implementNames, 3),
                 $this->listLabel(array_map(static fn (WorkoutLoadMention $load): string => $load->label(), $prescription->loads), 5),
+                $this->listLabel(array_map(static fn (WorkoutLoadCandidate $candidate): string => $candidate->label(), $prescription->loadCandidates), 5),
                 $this->flowPreview($workout),
             ];
         }
@@ -120,7 +122,7 @@ final class InferWorkoutPrescriptionPatternsCommand extends Command
         if ($rows !== []) {
             $table = new Table($output);
             $table
-                ->setHeaders(['Workout', 'Source', 'External ID', 'Levels', 'Divisions', 'Movements', 'Implements', 'Loads', 'Flow preview'])
+                ->setHeaders(['Workout', 'Source', 'External ID', 'Levels', 'Divisions', 'Movements', 'Implements', 'Loads', 'Candidates', 'Flow preview'])
                 ->setRows($rows);
             $table->render();
         } else {

--- a/src/Services/Workout/Prescription/InferredWorkoutPrescription.php
+++ b/src/Services/Workout/Prescription/InferredWorkoutPrescription.php
@@ -5,11 +5,12 @@ namespace App\Services\Workout\Prescription;
 final readonly class InferredWorkoutPrescription
 {
     /**
-     * @param list<string>             $divisionHints
-     * @param list<string>             $levelHints
-     * @param list<string>             $movementNames
-     * @param list<string>             $implementNames
-     * @param list<WorkoutLoadMention> $loads
+     * @param list<string>               $divisionHints
+     * @param list<string>               $levelHints
+     * @param list<string>               $movementNames
+     * @param list<string>               $implementNames
+     * @param list<WorkoutLoadMention>   $loads
+     * @param list<WorkoutLoadCandidate> $loadCandidates
      */
     public function __construct(
         public array $divisionHints,
@@ -17,6 +18,7 @@ final readonly class InferredWorkoutPrescription
         public array $movementNames,
         public array $implementNames,
         public array $loads,
+        public array $loadCandidates,
     ) {
     }
 

--- a/src/Services/Workout/Prescription/WorkoutLoadCandidate.php
+++ b/src/Services/Workout/Prescription/WorkoutLoadCandidate.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services\Workout\Prescription;
+
+final readonly class WorkoutLoadCandidate
+{
+    /**
+     * @param list<WorkoutLoadMention> $mentions
+     */
+    public function __construct(
+        public string $kind,
+        public string $equipmentHint,
+        public array $mentions,
+    ) {
+    }
+
+    public function label(): string
+    {
+        $mentions = implode(' ~= ', array_map(
+            static fn (WorkoutLoadMention $mention): string => $mention->loadLabel(),
+            $this->mentions,
+        ));
+        $equipment = $this->equipmentHint === 'unknown' ? '' : ' '.$this->equipmentHint;
+        $suffix = match ($this->kind) {
+            'conversion' => ' conversion',
+            'paired_load' => ' paired',
+            default => '',
+        };
+
+        return $mentions.$equipment.$suffix;
+    }
+}

--- a/src/Services/Workout/Prescription/WorkoutLoadMention.php
+++ b/src/Services/Workout/Prescription/WorkoutLoadMention.php
@@ -17,12 +17,17 @@ final readonly class WorkoutLoadMention
 
     public function label(): string
     {
+        $equipment = $this->equipmentHint === 'unknown' ? '' : ' '.$this->equipmentHint;
+
+        return $this->loadLabel().$equipment;
+    }
+
+    public function loadLabel(): string
+    {
         $values = implode('/', array_map(static function (float $value): string {
             return rtrim(rtrim(sprintf('%.2F', $value), '0'), '.');
         }, $this->values));
 
-        $equipment = $this->equipmentHint === 'unknown' ? '' : ' '.$this->equipmentHint;
-
-        return sprintf('%s %s%s', $values, $this->unit, $equipment);
+        return sprintf('%s %s', $values, $this->unit);
     }
 }

--- a/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
+++ b/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
@@ -20,13 +20,116 @@ final class WorkoutPrescriptionPatternInferer
             implode("\n", $divisionHints),
         ]));
 
+        $loads = $this->loads($text);
+
         return new InferredWorkoutPrescription(
             $divisionHints,
             $this->levelHints($text),
             $this->movementNames($workout),
             $this->implementNames($workout),
-            $this->loads($text),
+            $loads,
+            $this->loadCandidates($loads),
         );
+    }
+
+    /**
+     * @param list<WorkoutLoadMention> $loads
+     *
+     * @return list<WorkoutLoadCandidate>
+     */
+    private function loadCandidates(array $loads): array
+    {
+        $candidates = [];
+        $used = [];
+
+        foreach ($loads as $index => $load) {
+            if (isset($used[$index])) {
+                continue;
+            }
+
+            $conversionIndex = $this->matchingConversionLoadIndex($load, $loads, $used, $index);
+            if ($conversionIndex !== null) {
+                $candidates[] = new WorkoutLoadCandidate(
+                    'conversion',
+                    $this->candidateEquipmentHint($load, $loads[$conversionIndex]),
+                    [$load, $loads[$conversionIndex]],
+                );
+                $used[$index] = true;
+                $used[$conversionIndex] = true;
+                continue;
+            }
+
+            $candidates[] = new WorkoutLoadCandidate(
+                count($load->values) > 1 ? 'paired_load' : 'single_load',
+                $load->equipmentHint,
+                [$load],
+            );
+            $used[$index] = true;
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param list<WorkoutLoadMention> $loads
+     * @param array<int, true>         $used
+     */
+    private function matchingConversionLoadIndex(
+        WorkoutLoadMention $load,
+        array $loads,
+        array $used,
+        int $currentIndex,
+    ): ?int {
+        foreach ($loads as $candidateIndex => $candidate) {
+            if ($candidateIndex === $currentIndex || isset($used[$candidateIndex])) {
+                continue;
+            }
+            if (!$this->sameOrUnknownEquipment($load, $candidate)) {
+                continue;
+            }
+            if ($load->unit === $candidate->unit || count($load->values) !== count($candidate->values)) {
+                continue;
+            }
+            if ($this->areLoadValuesConversions($load, $candidate)) {
+                return $candidateIndex;
+            }
+        }
+
+        return null;
+    }
+
+    private function areLoadValuesConversions(WorkoutLoadMention $left, WorkoutLoadMention $right): bool
+    {
+        $lbValues = $left->unit === 'lb' ? $left->values : $right->values;
+        $kgValues = $left->unit === 'kg' ? $left->values : $right->values;
+
+        foreach ($lbValues as $index => $lbValue) {
+            $expectedKg = $lbValue * 0.45359237;
+            $actualKg = $kgValues[$index];
+            $tolerance = max(1.0, $expectedKg * 0.025);
+
+            if (abs($actualKg - $expectedKg) > $tolerance) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function candidateEquipmentHint(WorkoutLoadMention $left, WorkoutLoadMention $right): string
+    {
+        if ($left->equipmentHint !== 'unknown') {
+            return $left->equipmentHint;
+        }
+
+        return $right->equipmentHint;
+    }
+
+    private function sameOrUnknownEquipment(WorkoutLoadMention $left, WorkoutLoadMention $right): bool
+    {
+        return $left->equipmentHint === $right->equipmentHint
+            || $left->equipmentHint === 'unknown'
+            || $right->equipmentHint === 'unknown';
     }
 
     /**
@@ -94,10 +197,9 @@ final class WorkoutPrescriptionPatternInferer
 
     private function isPartOfPairedLoad(string $text, int $offset, int $length): bool
     {
-        $before = substr($text, max(0, $offset - 8), 8);
-        $after = substr($text, $offset + $length, 8);
+        $before = substr($text, max(0, $offset - 16), 16);
 
-        return str_contains($before, '/') || str_contains($after, '/');
+        return str_contains($before, '/') && preg_match('/(?:kg|kgs|lb|lbs)\s*\/\s*$/i', $before) !== 1;
     }
 
     private function equipmentHint(string $text, int $offset, int $length): string

--- a/tests/WorkoutPrescriptionPatternInfererTest.php
+++ b/tests/WorkoutPrescriptionPatternInfererTest.php
@@ -25,6 +25,7 @@ final class WorkoutPrescriptionPatternInfererTest extends TestCase
         self::assertSame([135.0, 95.0], $prescription->loads[0]->values);
         self::assertSame('lb', $prescription->loads[0]->unit);
         self::assertSame('barbell', $prescription->loads[0]->equipmentHint);
+        self::assertSame('135/95 lb barbell paired', $prescription->loadCandidates[0]->label());
     }
 
     public function testInfersSingleDumbbellAndRepeatedKettlebellLoads(): void
@@ -40,6 +41,21 @@ final class WorkoutPrescriptionPatternInfererTest extends TestCase
         self::assertCount(2, $prescription->loads);
         self::assertSame('50 lb dumbbell', $prescription->loads[0]->label());
         self::assertSame('24/24 kg kettlebell', $prescription->loads[1]->label());
+    }
+
+    public function testGroupsLbAndKgConversionsAsOneCandidate(): void
+    {
+        $workout = $this->workout(
+            'Age-Group Quarterfinals Workout 1 Men (35-39) Rx',
+            'For time: 20 overhead squats, weight 1: 80 lb / 36 kg. Then 30 overhead squats, weight 2: 115 lb / 52 kg.'
+        );
+
+        $prescription = (new WorkoutPrescriptionPatternInferer())->infer($workout);
+
+        self::assertCount(4, $prescription->loads);
+        self::assertCount(2, $prescription->loadCandidates);
+        self::assertSame('80 lb ~= 36 kg barbell conversion', $prescription->loadCandidates[0]->label());
+        self::assertSame('115 lb ~= 52 kg barbell conversion', $prescription->loadCandidates[1]->label());
     }
 
     private function workout(string $name, string $flow): Workout


### PR DESCRIPTION
Summary:
- add structured load candidates on top of raw load mentions
- group lb/kg conversions such as 80 lb ~= 36 kg
- label paired loads such as 135/95 lb as paired candidates
- expose candidates in the workout prescription report next to raw loads

Validation:
- php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutPrescriptionPatternInfererTest
- composer cs:check
- composer psalm
- php bin/console list app:workouts --env=test