### PR TITLE
Add workout prescription standards

### DIFF
--- a/migrations/Version20260520100000.php
+++ b/migrations/Version20260520100000.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260520100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add workout prescription standards for common CrossFit and HYROX loads.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE workout_prescription_standard (
+                id UUID NOT NULL,
+                source_name VARCHAR(64) NOT NULL,
+                sport VARCHAR(32) NOT NULL,
+                level_name VARCHAR(64) DEFAULT NULL,
+                division VARCHAR(32) NOT NULL,
+                movement_name VARCHAR(255) DEFAULT NULL,
+                implement_name VARCHAR(255) DEFAULT NULL,
+                quantity NUMERIC(8, 2) NOT NULL,
+                unit VARCHAR(32) NOT NULL,
+                quantity_multiplier INT NOT NULL,
+                context_label VARCHAR(255) DEFAULT NULL,
+                notes VARCHAR(255) DEFAULT NULL,
+                priority INT NOT NULL,
+                PRIMARY KEY(id)
+            )
+        SQL);
+        $this->addSql("COMMENT ON COLUMN workout_prescription_standard.id IS '(DC2Type:uuid)'");
+        $this->addSql('CREATE INDEX idx_workout_prescription_standard_scope ON workout_prescription_standard (sport, level_name, division)');
+        $this->addSql('CREATE INDEX idx_workout_prescription_standard_movement ON workout_prescription_standard (movement_name)');
+        $this->addSql('CREATE INDEX idx_workout_prescription_standard_implement ON workout_prescription_standard (implement_name)');
+
+        foreach ($this->standards() as $standard) {
+            $this->insertStandard($standard);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE workout_prescription_standard');
+    }
+
+    /**
+     * @return list<array{
+     *     id: string,
+     *     source_name: string,
+     *     sport: string,
+     *     level_name: string|null,
+     *     division: string,
+     *     movement_name: string|null,
+     *     implement_name: string|null,
+     *     quantity: float,
+     *     unit: string,
+     *     quantity_multiplier: int,
+     *     context_label: string|null,
+     *     notes: string|null,
+     *     priority: int
+     * }>
+     */
+    private function standards(): array
+    {
+        return [
+            $this->row('a1000000-0000-4000-8000-000000000001', 'hyrox_official_25_26', 'hyrox', 'RX', 'women', 'Sled Push', 'sled', 102, 'kg', 1, 'Open women', 'Includes sled', 10),
+            $this->row('a1000000-0000-4000-8000-000000000002', 'hyrox_official_25_26', 'hyrox', 'RX', 'men', 'Sled Push', 'sled', 152, 'kg', 1, 'Open men / mixed', 'Includes sled', 10),
+            $this->row('a1000000-0000-4000-8000-000000000003', 'hyrox_official_25_26', 'hyrox', 'Elite', 'women', 'Sled Push', 'sled', 152, 'kg', 1, 'Pro women', 'Includes sled', 10),
+            $this->row('a1000000-0000-4000-8000-000000000004', 'hyrox_official_25_26', 'hyrox', 'Elite', 'men', 'Sled Push', 'sled', 202, 'kg', 1, 'Pro men', 'Includes sled', 10),
+            $this->row('a1000000-0000-4000-8000-000000000005', 'hyrox_official_25_26', 'hyrox', 'RX', 'women', 'Sled Pull', 'sled', 78, 'kg', 1, 'Open women', 'Includes sled', 10),
+            $this->row('a1000000-0000-4000-8000-000000000006', 'hyrox_official_25_26', 'hyrox', 'RX', 'men', 'Sled Pull', 'sled', 103, 'kg', 1, 'Open men / mixed', 'Includes sled', 10),
+            $this->row('a1000000-0000-4000-8000-000000000007', 'hyrox_official_25_26', 'hyrox', 'Elite', 'women', 'Sled Pull', 'sled', 103, 'kg', 1, 'Pro women', 'Includes sled', 10),
+            $this->row('a1000000-0000-4000-8000-000000000008', 'hyrox_official_25_26', 'hyrox', 'Elite', 'men', 'Sled Pull', 'sled', 153, 'kg', 1, 'Pro men', 'Includes sled', 10),
+            $this->row('a1000000-0000-4000-8000-000000000009', 'hyrox_official_25_26', 'hyrox', 'RX', 'women', 'Farmer Carry', 'kettlebell', 16, 'kg', 2, 'Open women', null, 10),
+            $this->row('a1000000-0000-4000-8000-000000000010', 'hyrox_official_25_26', 'hyrox', 'RX', 'men', 'Farmer Carry', 'kettlebell', 24, 'kg', 2, 'Open men / mixed', null, 10),
+            $this->row('a1000000-0000-4000-8000-000000000011', 'hyrox_official_25_26', 'hyrox', 'Elite', 'women', 'Farmer Carry', 'kettlebell', 24, 'kg', 2, 'Pro women', null, 10),
+            $this->row('a1000000-0000-4000-8000-000000000012', 'hyrox_official_25_26', 'hyrox', 'Elite', 'men', 'Farmer Carry', 'kettlebell', 32, 'kg', 2, 'Pro men', null, 10),
+            $this->row('a1000000-0000-4000-8000-000000000013', 'hyrox_official_25_26', 'hyrox', 'RX', 'women', 'Walking Lunge', 'sand bag', 10, 'kg', 1, 'Open women sandbag lunges', null, 10),
+            $this->row('a1000000-0000-4000-8000-000000000014', 'hyrox_official_25_26', 'hyrox', 'RX', 'men', 'Walking Lunge', 'sand bag', 20, 'kg', 1, 'Open men / mixed sandbag lunges', null, 10),
+            $this->row('a1000000-0000-4000-8000-000000000015', 'hyrox_official_25_26', 'hyrox', 'Elite', 'women', 'Walking Lunge', 'sand bag', 20, 'kg', 1, 'Pro women sandbag lunges', null, 10),
+            $this->row('a1000000-0000-4000-8000-000000000016', 'hyrox_official_25_26', 'hyrox', 'Elite', 'men', 'Walking Lunge', 'sand bag', 30, 'kg', 1, 'Pro men sandbag lunges', null, 10),
+            $this->row('a1000000-0000-4000-8000-000000000017', 'hyrox_official_25_26', 'hyrox', 'RX', 'women', 'Wall Ball Shot', 'medicine ball', 4, 'kg', 1, 'Open women', '100 reps', 10),
+            $this->row('a1000000-0000-4000-8000-000000000018', 'hyrox_official_25_26', 'hyrox', 'RX', 'men', 'Wall Ball Shot', 'medicine ball', 6, 'kg', 1, 'Open men / mixed', '100 reps', 10),
+            $this->row('a1000000-0000-4000-8000-000000000019', 'hyrox_official_25_26', 'hyrox', 'Elite', 'women', 'Wall Ball Shot', 'medicine ball', 6, 'kg', 1, 'Pro women', '100 reps', 10),
+            $this->row('a1000000-0000-4000-8000-000000000020', 'hyrox_official_25_26', 'hyrox', 'Elite', 'men', 'Wall Ball Shot', 'medicine ball', 9, 'kg', 1, 'Pro men', '100 reps', 10),
+            $this->row('a1000000-0000-4000-8000-000000000021', 'crossfit_common', 'crossfit', 'RX', 'men', null, 'dumbbell', 22.5, 'kg', 1, 'Common RX single dumbbell', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000022', 'crossfit_common', 'crossfit', 'RX', 'women', null, 'dumbbell', 15, 'kg', 1, 'Common RX single dumbbell', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000023', 'crossfit_common', 'crossfit', 'Elite', 'men', null, 'dumbbell', 32.5, 'kg', 1, 'Common Elite single dumbbell', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000024', 'crossfit_common', 'crossfit', 'Elite', 'women', null, 'dumbbell', 22.5, 'kg', 1, 'Common Elite single dumbbell', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000025', 'crossfit_common', 'crossfit', 'RX', 'men', null, 'kettlebell', 24, 'kg', 1, 'Common RX kettlebell', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000026', 'crossfit_common', 'crossfit', 'RX', 'women', null, 'kettlebell', 16, 'kg', 1, 'Common RX kettlebell', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000027', 'crossfit_common', 'crossfit', 'Elite', 'men', null, 'kettlebell', 32, 'kg', 1, 'Common Elite kettlebell', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000028', 'crossfit_common', 'crossfit', 'Elite', 'women', null, 'kettlebell', 24, 'kg', 1, 'Common Elite kettlebell', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000029', 'crossfit_common', 'crossfit', 'RX', 'men', 'Wall Ball Shot', 'medicine ball', 9, 'kg', 1, 'Common RX wall ball', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000030', 'crossfit_common', 'crossfit', 'RX', 'women', 'Wall Ball Shot', 'medicine ball', 6, 'kg', 1, 'Common RX wall ball', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000031', 'crossfit_common', 'crossfit', 'Elite', 'men', 'Wall Ball Shot', 'medicine ball', 12, 'kg', 1, 'Common Elite wall ball', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000032', 'crossfit_common', 'crossfit', 'Elite', 'women', 'Wall Ball Shot', 'medicine ball', 9, 'kg', 1, 'Common Elite wall ball', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000033', 'crossfit_common', 'crossfit', 'RX', 'men', 'Thruster', 'barbell', 42.5, 'kg', 1, '95 lb-style RX thruster', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000034', 'crossfit_common', 'crossfit', 'RX', 'women', 'Thruster', 'barbell', 30, 'kg', 1, '65 lb-style RX thruster', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000035', 'crossfit_common', 'crossfit', 'Elite', 'men', 'Thruster', 'barbell', 61, 'kg', 1, '135 lb-style Elite thruster', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000036', 'crossfit_common', 'crossfit', 'Elite', 'women', 'Thruster', 'barbell', 43, 'kg', 1, '95 lb-style Elite thruster', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000037', 'crossfit_common', 'crossfit', 'RX', 'men', 'Deadlift', 'barbell', 102, 'kg', 1, '225 lb-style RX deadlift', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000038', 'crossfit_common', 'crossfit', 'RX', 'women', 'Deadlift', 'barbell', 70, 'kg', 1, '155 lb-style RX deadlift', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000039', 'crossfit_common', 'crossfit', 'Elite', 'men', 'Deadlift', 'barbell', 143, 'kg', 1, '315 lb-style Elite deadlift', null, 30),
+            $this->row('a1000000-0000-4000-8000-000000000040', 'crossfit_common', 'crossfit', 'Elite', 'women', 'Deadlift', 'barbell', 102, 'kg', 1, '225 lb-style Elite deadlift', null, 30),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     source_name: string,
+     *     sport: string,
+     *     level_name: string|null,
+     *     division: string,
+     *     movement_name: string|null,
+     *     implement_name: string|null,
+     *     quantity: float,
+     *     unit: string,
+     *     quantity_multiplier: int,
+     *     context_label: string|null,
+     *     notes: string|null,
+     *     priority: int
+     * }
+     */
+    private function row(
+        string $id,
+        string $sourceName,
+        string $sport,
+        ?string $levelName,
+        string $division,
+        ?string $movementName,
+        ?string $implementName,
+        float $quantity,
+        string $unit,
+        int $quantityMultiplier,
+        ?string $contextLabel,
+        ?string $notes,
+        int $priority,
+    ): array {
+        return [
+            'id' => $id,
+            'source_name' => $sourceName,
+            'sport' => $sport,
+            'level_name' => $levelName,
+            'division' => $division,
+            'movement_name' => $movementName,
+            'implement_name' => $implementName,
+            'quantity' => $quantity,
+            'unit' => $unit,
+            'quantity_multiplier' => $quantityMultiplier,
+            'context_label' => $contextLabel,
+            'notes' => $notes,
+            'priority' => $priority,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $standard
+     */
+    private function insertStandard(array $standard): void
+    {
+        $columns = array_keys($standard);
+        $values = array_map(fn (mixed $value): string => $this->sqlValue($value), array_values($standard));
+
+        $this->addSql(sprintf(
+            'INSERT INTO workout_prescription_standard (%s) VALUES (%s)',
+            implode(', ', $columns),
+            implode(', ', $values),
+        ));
+    }
+
+    private function sqlValue(mixed $value): string
+    {
+        if ($value === null) {
+            return 'NULL';
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        return "'".str_replace("'", "''", (string) $value)."'";
+    }
+}

--- a/src/Entity/Workout/WorkoutPrescriptionStandard.php
+++ b/src/Entity/Workout/WorkoutPrescriptionStandard.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Entity\Workout;
+
+use App\Repository\Workout\WorkoutPrescriptionStandardRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+#[ORM\Entity(repositoryClass: WorkoutPrescriptionStandardRepository::class)]
+#[ORM\Index(columns: ['sport', 'level_name', 'division'], name: 'idx_workout_prescription_standard_scope')]
+#[ORM\Index(columns: ['movement_name'], name: 'idx_workout_prescription_standard_movement')]
+#[ORM\Index(columns: ['implement_name'], name: 'idx_workout_prescription_standard_implement')]
+class WorkoutPrescriptionStandard
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    private ?Uuid $id = null;
+
+    public function __construct(
+        #[ORM\Column(length: 64)]
+        private string $sourceName,
+        #[ORM\Column(length: 32)]
+        private string $sport,
+        #[ORM\Column(length: 64, nullable: true)]
+        private ?string $levelName,
+        #[ORM\Column(length: 32)]
+        private string $division,
+        #[ORM\Column(length: 255, nullable: true)]
+        private ?string $movementName,
+        #[ORM\Column(length: 255, nullable: true)]
+        private ?string $implementName,
+        #[ORM\Column(type: 'decimal', precision: 8, scale: 2)]
+        private string $quantity,
+        #[ORM\Column(length: 32)]
+        private string $unit,
+        #[ORM\Column(type: 'integer')]
+        private int $quantityMultiplier = 1,
+        #[ORM\Column(length: 255, nullable: true)]
+        private ?string $contextLabel = null,
+        #[ORM\Column(length: 255, nullable: true)]
+        private ?string $notes = null,
+        #[ORM\Column(type: 'integer')]
+        private int $priority = 100,
+    ) {
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getSourceName(): string
+    {
+        return $this->sourceName;
+    }
+
+    public function getSport(): string
+    {
+        return $this->sport;
+    }
+
+    public function getLevelName(): ?string
+    {
+        return $this->levelName;
+    }
+
+    public function getDivision(): string
+    {
+        return $this->division;
+    }
+
+    public function getMovementName(): ?string
+    {
+        return $this->movementName;
+    }
+
+    public function getImplementName(): ?string
+    {
+        return $this->implementName;
+    }
+
+    public function getQuantity(): float
+    {
+        return (float) $this->quantity;
+    }
+
+    public function getUnit(): string
+    {
+        return $this->unit;
+    }
+
+    public function getQuantityMultiplier(): int
+    {
+        return $this->quantityMultiplier;
+    }
+
+    public function getContextLabel(): ?string
+    {
+        return $this->contextLabel;
+    }
+
+    public function getNotes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+
+    public function label(): string
+    {
+        $quantity = rtrim(rtrim(number_format($this->getQuantity(), 2, '.', ''), '0'), '.');
+        $load = ($this->quantityMultiplier > 1 ? $this->quantityMultiplier.' x ' : '').$quantity.' '.$this->unit;
+        $target = $this->movementName ?? $this->implementName ?? 'loaded movement';
+        $context = $this->contextLabel === null ? '' : ' ('.$this->contextLabel.')';
+        $notes = $this->notes === null ? '' : ' - '.$this->notes;
+
+        return sprintf('%s %s: %s%s%s', ucfirst($this->division), $target, $load, $context, $notes);
+    }
+}

--- a/src/Repository/Workout/WorkoutPrescriptionStandardRepository.php
+++ b/src/Repository/Workout/WorkoutPrescriptionStandardRepository.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Repository\Workout;
+
+use App\Entity\Workout\WorkoutPrescriptionStandard;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<WorkoutPrescriptionStandard>
+ *
+ * @method WorkoutPrescriptionStandard|null find($id, $lockMode = null, $lockVersion = null)
+ * @method WorkoutPrescriptionStandard|null findOneBy(array $criteria, array $orderBy = null)
+ * @method WorkoutPrescriptionStandard[]    findAll()
+ * @method WorkoutPrescriptionStandard[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class WorkoutPrescriptionStandardRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, WorkoutPrescriptionStandard::class);
+    }
+
+    /**
+     * @param list<string> $movementNames
+     * @param list<string> $implementNames
+     *
+     * @return list<WorkoutPrescriptionStandard>
+     */
+    public function findForPrompt(
+        string $levelName,
+        array $movementNames,
+        array $implementNames,
+        bool $includeHyrox,
+        int $limit = 30,
+    ): array {
+        $query = $this->createQueryBuilder('standard')
+            ->where('(standard.levelName = :levelName OR standard.levelName IS NULL)')
+            ->andWhere($includeHyrox ? 'standard.sport IN (:sports)' : 'standard.sport = :sport')
+            ->setParameter('levelName', $levelName)
+            ->orderBy('standard.priority', 'ASC')
+            ->addOrderBy('standard.sport', 'ASC')
+            ->addOrderBy('standard.implementName', 'ASC')
+            ->addOrderBy('standard.movementName', 'ASC')
+            ->addOrderBy('standard.division', 'ASC')
+            ->setMaxResults($limit);
+
+        if ($includeHyrox) {
+            $query->setParameter('sports', ['crossfit', 'hyrox']);
+        } else {
+            $query->setParameter('sport', 'crossfit');
+        }
+
+        $orExpressions = ['standard.movementName IS NULL AND standard.implementName IS NULL'];
+        if ($movementNames !== []) {
+            $orExpressions[] = 'standard.movementName IN (:movementNames)';
+            $query->setParameter('movementNames', $movementNames);
+        }
+        if ($implementNames !== []) {
+            $orExpressions[] = 'standard.implementName IN (:implementNames)';
+            $query->setParameter('implementNames', $implementNames);
+        }
+        if ($includeHyrox) {
+            $orExpressions[] = 'standard.sport = :hyroxSport';
+            $query->setParameter('hyroxSport', 'hyrox');
+        }
+
+        return $query
+            ->andWhere('('.implode(' OR ', $orExpressions).')')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Services/Workout/WorkoutCreatorService.php
+++ b/src/Services/Workout/WorkoutCreatorService.php
@@ -15,6 +15,7 @@ readonly class WorkoutCreatorService implements WorkoutCreatorServiceInterface
         public MovementServiceInterface $movementService,
         public ChatGPTApiKeyInterface $chatGPTApiKey,
         public WorkoutOriginServiceInterface $workoutOriginService,
+        private ?WorkoutPrescriptionStandardPromptBuilder $prescriptionStandardPromptBuilder = null,
     ) {
     }
 
@@ -72,6 +73,7 @@ readonly class WorkoutCreatorService implements WorkoutCreatorServiceInterface
         $promptForChatGPT .= $this->teamWorkoutGuidance($workoutGeneration);
         $promptForChatGPT .= "Make the final workout flow match the stimulus identity and intent.\n";
         $promptForChatGPT .= $this->levelPrescriptionGuidance($workoutGeneration);
+        $promptForChatGPT .= $this->prescriptionStandardGuidance($workoutGeneration, array_merge($mandatoryMovements, $candidateMovements));
         $promptForChatGPT .= <<<EOD
 When prescribing loaded movements, always include level-appropriate male/female loads in kg when relevant. Use heavier and more technical prescriptions for Elite, standard competitive prescriptions for RX, sustainable prescriptions for Intermediate, and accessible prescriptions for Scaled/Beginner.
 Add a short "Scaling options" section at the end of the flow with practical adaptations for RX, Intermediate and Scaled athletes. Preserve the intended stimulus when scaling: change load, range of motion, movement complexity, reps or distance before changing the workout goal.
@@ -287,6 +289,18 @@ EOD;
 Team workout guidance: this must be explicitly written as a team workout. Use team-of-2 unless another team size is clearly better for the stimulus. Include a clear work-sharing pattern such as "you go, I go", shared reps, split anyhow, synchronized reps, relay stations or partner alternating rounds. The flow must make the team structure impossible to miss.
 
 TXT;
+    }
+
+    /**
+     * @param Movement[] $movements
+     */
+    private function prescriptionStandardGuidance(WorkoutGeneration $workoutGeneration, array $movements): string
+    {
+        if (!$this->prescriptionStandardPromptBuilder instanceof WorkoutPrescriptionStandardPromptBuilder) {
+            return '';
+        }
+
+        return $this->prescriptionStandardPromptBuilder->build($workoutGeneration, $movements);
     }
 
     /**

--- a/src/Services/Workout/WorkoutPrescriptionStandardPromptBuilder.php
+++ b/src/Services/Workout/WorkoutPrescriptionStandardPromptBuilder.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Services\Workout;
+
+use App\Entity\Workout\Movement;
+use App\Entity\Workout\WorkoutPrescriptionStandard;
+use App\Entity\WorkoutGeneration\WorkoutGeneration;
+use App\Repository\Workout\WorkoutPrescriptionStandardRepository;
+
+readonly class WorkoutPrescriptionStandardPromptBuilder
+{
+    public function __construct(
+        private WorkoutPrescriptionStandardRepository $standardRepository,
+    ) {
+    }
+
+    /**
+     * @param Movement[] $movements
+     */
+    public function build(WorkoutGeneration $workoutGeneration, array $movements): string
+    {
+        $standards = $this->standardRepository->findForPrompt(
+            $workoutGeneration->getMovementDifficulty()->getName(),
+            $this->movementNames($movements),
+            $this->implementNames($workoutGeneration, $movements),
+            $this->isHyroxIntent($workoutGeneration),
+        );
+
+        if ($standards === []) {
+            return '';
+        }
+
+        $prompt = "Known load prescription standards to prefer when relevant:\n";
+        foreach ($this->groupByScope($standards) as $scope => $scopeStandards) {
+            $prompt .= sprintf("- %s\n", $scope);
+            foreach ($scopeStandards as $standard) {
+                $prompt .= sprintf("  - %s\n", $standard->label());
+            }
+        }
+
+        return $prompt."Use these as anchors, not as mandatory loads for every movement. If the requested stimulus, level or implement makes a different load safer or more coherent, explain it through the scaling options.\n";
+    }
+
+    /**
+     * @param Movement[] $movements
+     *
+     * @return list<string>
+     */
+    private function movementNames(array $movements): array
+    {
+        return array_values(array_unique(array_map(
+            static fn (Movement $movement): string => (string) $movement->getName(),
+            $movements,
+        )));
+    }
+
+    /**
+     * @param Movement[] $movements
+     *
+     * @return list<string>
+     */
+    private function implementNames(WorkoutGeneration $workoutGeneration, array $movements): array
+    {
+        $implementNames = [];
+        foreach ($workoutGeneration->getAvailableImplements() as $implement) {
+            $implementNames[] = $implement->getName();
+        }
+        foreach ($movements as $movement) {
+            foreach ($movement->getPossibleImplements() as $implement) {
+                $implementNames[] = $implement->getName();
+            }
+        }
+
+        return array_values(array_unique($implementNames));
+    }
+
+    private function isHyroxIntent(WorkoutGeneration $workoutGeneration): bool
+    {
+        $haystack = strtolower(trim(sprintf(
+            '%s %s %s',
+            $workoutGeneration->getName(),
+            $workoutGeneration->getStimulus() ?? '',
+            $workoutGeneration->getStimulusIntent() ?? '',
+        )));
+
+        return str_contains($haystack, 'hyrox');
+    }
+
+    /**
+     * @param list<WorkoutPrescriptionStandard> $standards
+     *
+     * @return array<string, list<WorkoutPrescriptionStandard>>
+     */
+    private function groupByScope(array $standards): array
+    {
+        $groups = [];
+        foreach ($standards as $standard) {
+            $level = $standard->getLevelName() ?? 'all levels';
+            $groups[$standard->getSport().' / '.$level.' / '.$standard->getSourceName()][] = $standard;
+        }
+
+        return $groups;
+    }
+}

--- a/tests/WorkoutCreatorServiceTest.php
+++ b/tests/WorkoutCreatorServiceTest.php
@@ -13,12 +13,15 @@ use App\Entity\Workout\MovementType;
 use App\Entity\Workout\WorkoutMovementGenerationType;
 use App\Entity\Workout\WorkoutOrigin;
 use App\Entity\Workout\WorkoutOriginName;
+use App\Entity\Workout\WorkoutPrescriptionStandard;
 use App\Entity\Workout\WorkoutType;
 use App\Entity\WorkoutGeneration\WorkoutGeneration;
+use App\Repository\Workout\WorkoutPrescriptionStandardRepository;
 use App\Services\Workout\ChatGPTApiKeyInterface;
 use App\Services\Workout\MovementServiceInterface;
 use App\Services\Workout\WorkoutCreatorService;
 use App\Services\Workout\WorkoutOriginServiceInterface;
+use App\Services\Workout\WorkoutPrescriptionStandardPromptBuilder;
 use Doctrine\Common\Collections\Collection;
 use PHPUnit\Framework\TestCase;
 
@@ -209,5 +212,39 @@ class WorkoutCreatorServiceTest extends TestCase
         self::assertStringContainsString('this must be explicitly written as a team workout', $chatGpt->prompt);
         self::assertStringContainsString('team-of-2', $chatGpt->prompt);
         self::assertStringContainsString('you go, I go', $chatGpt->prompt);
+    }
+
+    public function testPrescriptionStandardPromptBuilderAddsRelevantHyroxAndCrossfitLoads(): void
+    {
+        $difficulty = new MovementDifficulty(MovementDifficultyEnum::RX);
+        $weightlifting = new MovementType(MovementTypeEnum::WEIGHTLIFTING);
+        $deadlift = new Movement('Deadlift', $difficulty, $weightlifting);
+
+        $repository = $this->createMock(WorkoutPrescriptionStandardRepository::class);
+        $repository
+            ->expects(self::once())
+            ->method('findForPrompt')
+            ->with('RX', ['Deadlift'], [], true)
+            ->willReturn([
+                new WorkoutPrescriptionStandard('hyrox_official_25_26', 'hyrox', 'RX', 'men', 'Sled Push', 'sled', '152.00', 'kg', 1, 'Open men / mixed', 'Includes sled', 10),
+                new WorkoutPrescriptionStandard('crossfit_common', 'crossfit', 'RX', 'women', 'Deadlift', 'barbell', '70.00', 'kg', 1, '155 lb-style RX deadlift', null, 30),
+            ]);
+
+        $workoutGeneration = (new WorkoutGeneration())
+            ->setName('Hyrox strength')
+            ->setStimulus('Wod axé Hyrox')
+            ->setWorkoutType(new WorkoutType(WorkoutTypeEnum::FOR_TIME))
+            ->setMovementGenerationType(new WorkoutMovementGenerationType(WorkoutMovementGenerationTypeEnum::MOVEMENT))
+            ->setMovementDifficulty($difficulty)
+            ->setNumberOfDifferentMovements(1)
+            ->setIsTeamWorkout(false);
+
+        $prompt = (new WorkoutPrescriptionStandardPromptBuilder($repository))->build($workoutGeneration, [$deadlift]);
+
+        self::assertStringContainsString('Known load prescription standards', $prompt);
+        self::assertStringContainsString('hyrox / RX / hyrox_official_25_26', $prompt);
+        self::assertStringContainsString('Men Sled Push: 152 kg (Open men / mixed) - Includes sled', $prompt);
+        self::assertStringContainsString('Women Deadlift: 70 kg (155 lb-style RX deadlift)', $prompt);
+        self::assertStringContainsString('Use these as anchors', $prompt);
     }
 }


### PR DESCRIPTION
## Summary
- add a workout prescription standard table for load anchors by source, sport, level, division, movement and implement
- seed initial HYROX official 25/26 Open/Pro standards and common CrossFit RX/Elite load anchors
- inject matching standards into the OpenAI workout generation prompt when relevant, including HYROX-intent workouts

## Notes
- HYROX rows follow the 25/26 singles rulebook weights for sled push/pull, farmers carry, sandbag lunges and wall balls.
- CrossFit rows are practical common anchors, not hard rules; the prompt tells the model to use them as guidance and preserve scaling options.

## Validation
- php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutCreatorServiceTest
- composer cs:check
- composer psalm
- git diff --check
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php bin/console doctrine:migrations:migrate --env=test --no-interaction
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php bin/console doctrine:schema:validate --env=test
