### PR TITLE
Enrich workout load inference context

### DIFF
--- a/src/Command/InferWorkoutPrescriptionPatternsCommand.php
+++ b/src/Command/InferWorkoutPrescriptionPatternsCommand.php
@@ -237,6 +237,11 @@ final class InferWorkoutPrescriptionPatternsCommand extends Command
      *     values: list<float>,
      *     unit: string,
      *     equipmentHint: string,
+     *     offset: int,
+     *     nearText: string,
+     *     positionLabel: string|null,
+     *     audienceHint: string|null,
+     *     movementHint: string|null,
      *     label: string
      * }
      */
@@ -247,6 +252,11 @@ final class InferWorkoutPrescriptionPatternsCommand extends Command
             'values' => $load->values,
             'unit' => $load->unit,
             'equipmentHint' => $load->equipmentHint,
+            'offset' => $load->offset,
+            'nearText' => $load->nearText,
+            'positionLabel' => $load->positionLabel,
+            'audienceHint' => $load->audienceHint,
+            'movementHint' => $load->movementHint,
             'label' => $load->label(),
         ];
     }
@@ -256,11 +266,17 @@ final class InferWorkoutPrescriptionPatternsCommand extends Command
      *     kind: string,
      *     equipmentHint: string,
      *     label: string,
+     *     contextHints: array<string, list<string>>,
      *     mentions: list<array{
      *         raw: string,
      *         values: list<float>,
      *         unit: string,
      *         equipmentHint: string,
+     *         offset: int,
+     *         nearText: string,
+     *         positionLabel: string|null,
+     *         audienceHint: string|null,
+     *         movementHint: string|null,
      *         label: string
      *     }>
      * }
@@ -271,6 +287,7 @@ final class InferWorkoutPrescriptionPatternsCommand extends Command
             'kind' => $candidate->kind,
             'equipmentHint' => $candidate->equipmentHint,
             'label' => $candidate->label(),
+            'contextHints' => $candidate->contextHints(),
             'mentions' => array_map($this->loadPayload(...), $candidate->mentions),
         ];
     }

--- a/src/Services/Workout/Prescription/WorkoutLoadCandidate.php
+++ b/src/Services/Workout/Prescription/WorkoutLoadCandidate.php
@@ -29,4 +29,34 @@ final readonly class WorkoutLoadCandidate
 
         return $mentions.$equipment.$suffix;
     }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function contextHints(): array
+    {
+        return [
+            'positions' => $this->uniqueMentionValues(static fn (WorkoutLoadMention $mention): ?string => $mention->positionLabel),
+            'audiences' => $this->uniqueMentionValues(static fn (WorkoutLoadMention $mention): ?string => $mention->audienceHint),
+            'movements' => $this->uniqueMentionValues(static fn (WorkoutLoadMention $mention): ?string => $mention->movementHint),
+        ];
+    }
+
+    /**
+     * @param callable(WorkoutLoadMention): ?string $value
+     *
+     * @return list<string>
+     */
+    private function uniqueMentionValues(callable $value): array
+    {
+        $values = [];
+        foreach ($this->mentions as $mention) {
+            $hint = $value($mention);
+            if ($hint !== null) {
+                $values[$hint] = true;
+            }
+        }
+
+        return array_keys($values);
+    }
 }

--- a/src/Services/Workout/Prescription/WorkoutLoadMention.php
+++ b/src/Services/Workout/Prescription/WorkoutLoadMention.php
@@ -12,6 +12,11 @@ final readonly class WorkoutLoadMention
         public array $values,
         public string $unit,
         public string $equipmentHint,
+        public int $offset,
+        public string $nearText,
+        public ?string $positionLabel,
+        public ?string $audienceHint,
+        public ?string $movementHint,
     ) {
     }
 

--- a/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
+++ b/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
@@ -148,6 +148,11 @@ final class WorkoutPrescriptionPatternInferer
                     [$this->floatValue($match['first'][0]), $this->floatValue($match['second'][0])],
                     $this->unit($match['unit'][0]),
                     $this->equipmentHint($text, (int) $match[0][1], strlen($raw)),
+                    (int) $match[0][1],
+                    $this->nearText($text, (int) $match[0][1], strlen($raw)),
+                    $this->positionLabel($text, (int) $match[0][1], strlen($raw)),
+                    $this->audienceHint($text, (int) $match[0][1], strlen($raw)),
+                    $this->movementHint($text, (int) $match[0][1], strlen($raw)),
                 );
                 $this->addLoad($loads, $seen, $load);
             }
@@ -172,6 +177,11 @@ final class WorkoutPrescriptionPatternInferer
                     $values,
                     $this->unit($match['unit'][0]),
                     $this->equipmentHint($text, $offset, strlen($raw)),
+                    $offset,
+                    $this->nearText($text, $offset, strlen($raw)),
+                    $this->positionLabel($text, $offset, strlen($raw)),
+                    $this->audienceHint($text, $offset, strlen($raw)),
+                    $this->movementHint($text, $offset, strlen($raw)),
                 );
                 $this->addLoad($loads, $seen, $load);
             }
@@ -186,7 +196,7 @@ final class WorkoutPrescriptionPatternInferer
      */
     private function addLoad(array &$loads, array &$seen, WorkoutLoadMention $load): void
     {
-        $key = strtolower($load->raw.'|'.$load->equipmentHint);
+        $key = strtolower($load->raw.'|'.$load->equipmentHint.'|'.$load->offset);
         if (isset($seen[$key])) {
             return;
         }
@@ -234,7 +244,107 @@ final class WorkoutPrescriptionPatternInferer
             }
         }
 
-        return $closestHint ?? 'unknown';
+        if ($closestHint !== null) {
+            return $closestHint;
+        }
+
+        return match ($this->movementHint($text, $offset, $length)) {
+            'Deadlift', 'Clean', 'Clean and Jerk', 'Front Squat', 'Overhead Squat', 'Snatch', 'Thruster' => 'barbell',
+            'Wall Ball Shot' => 'medicine ball',
+            'Farmer Carry' => 'kettlebell',
+            'Sled Push', 'Sled Pull' => 'sled',
+            'Walking Lunge' => 'sandbag',
+            default => 'unknown',
+        };
+    }
+
+    private function nearText(string $text, int $offset, int $length): string
+    {
+        $windowStart = max(0, $offset - 90);
+        $window = substr($text, $windowStart, $length + 180);
+
+        return trim((string) preg_replace('/\s+/', ' ', $window));
+    }
+
+    private function positionLabel(string $text, int $offset, int $length): ?string
+    {
+        $weightPosition = $this->closestPatternLabel($text, $offset, $length, [
+            'weight_1' => '/\b(?:weight|load)\s*1\b/i',
+            'weight_2' => '/\b(?:weight|load)\s*2\b/i',
+            'weight_3' => '/\b(?:weight|load)\s*3\b/i',
+        ], 120);
+
+        if ($weightPosition !== null) {
+            return $weightPosition;
+        }
+
+        return $this->closestPatternLabel($text, $offset, $length, [
+            'heaviest' => '/\bheaviest\b/i',
+            'lightest' => '/\blightest\b/i',
+        ], 120);
+    }
+
+    private function audienceHint(string $text, int $offset, int $length): ?string
+    {
+        return $this->closestPatternLabel($text, $offset, $length, [
+            'ff' => '/\bFF\b|\(FF\)/',
+            'mm' => '/\bMM\b|\(MM\)/',
+            'mixed' => '/\b(?:mixed|MF|FM)\b/',
+            'women' => '/\b(?:women|woman|female|girls?)\b/i',
+            'men' => '/\b(?:men|man|male|boys?)\b/i',
+            'team_pair' => '/\b(?:team|pairs?|partner|teammates?|synchronized)\b/i',
+        ], 100);
+    }
+
+    private function movementHint(string $text, int $offset, int $length): ?string
+    {
+        return $this->closestPatternLabel($text, $offset, $length, [
+            'Clean and Jerk' => '/\bclean(?:s)? and jerk(?:s)?\b/i',
+            'Hang Power Clean' => '/\bhang power clean(?:s)?\b/i',
+            'Squat Clean' => '/\bsquat clean(?:s)?\b/i',
+            'Front Squat' => '/\bfront squat(?:s)?\b/i',
+            'Overhead Squat' => '/\boverhead squat(?:s)?\b/i',
+            'Deadlift' => '/\bdeadlift(?:s)?\b/i',
+            'Thruster' => '/\bthruster(?:s)?\b/i',
+            'Snatch' => '/\bsnatch(?:es)?\b/i',
+            'Wall Ball Shot' => '/\bwall[- ]ball(?: shots?)?\b/i',
+            'Farmer Carry' => '/\bfarmer(?:\'s)? carr(?:y|ies)\b/i',
+            'Sled Push' => '/\bsled push\b/i',
+            'Sled Pull' => '/\bsled pull\b/i',
+            'Walking Lunge' => '/\b(?:walking )?lunge(?:s)?\b/i',
+            'Box Jump' => '/\bbox jump(?:s)?\b/i',
+            'Handstand Push Up' => '/\bhandstand push[- ]ups?\b/i',
+            'Clean' => '/\bclean(?:s)?\b/i',
+        ], 120);
+    }
+
+    /**
+     * @param array<string, string> $patterns
+     */
+    private function closestPatternLabel(string $text, int $offset, int $length, array $patterns, int $radius): ?string
+    {
+        $windowStart = max(0, $offset - $radius);
+        $window = substr($text, $windowStart, $length + ($radius * 2));
+        $loadCenter = $offset - $windowStart + (int) floor($length / 2);
+        $closestLabel = null;
+        $closestDistance = PHP_INT_MAX;
+
+        foreach ($patterns as $label => $pattern) {
+            if (preg_match_all($pattern, $window, $matches, PREG_OFFSET_CAPTURE) < 1) {
+                continue;
+            }
+
+            foreach ($matches[0] as $match) {
+                $position = (int) $match[1];
+                $distance = abs(($position + (int) floor(strlen($match[0]) / 2)) - $loadCenter);
+                if ($distance < $closestDistance) {
+                    $closestLabel = $label;
+                    $closestDistance = $distance;
+                }
+            }
+        }
+
+        return $closestLabel;
     }
 
     /**

--- a/tests/WorkoutPrescriptionPatternInfererTest.php
+++ b/tests/WorkoutPrescriptionPatternInfererTest.php
@@ -58,6 +58,42 @@ final class WorkoutPrescriptionPatternInfererTest extends TestCase
         self::assertSame('115 lb ~= 52 kg barbell conversion', $prescription->loadCandidates[1]->label());
     }
 
+    public function testAddsContextHintsToWeightPositionLoads(): void
+    {
+        $workout = $this->workout(
+            'Workout 5',
+            '21 deadlifts, weight 1 (lightest) at 205 lb. 15 deadlifts, weight 2 (heaviest) at 315 lb. Then 15 bar muscle-ups.'
+        );
+
+        $prescription = (new WorkoutPrescriptionPatternInferer())->infer($workout);
+
+        self::assertCount(2, $prescription->loads);
+        self::assertSame('weight_1', $prescription->loads[0]->positionLabel);
+        self::assertSame('Deadlift', $prescription->loads[0]->movementHint);
+        self::assertSame('barbell', $prescription->loads[0]->equipmentHint);
+        self::assertStringContainsString('weight 1', $prescription->loads[0]->nearText);
+        self::assertSame('weight_2', $prescription->loads[1]->positionLabel);
+        self::assertSame(['weight_1'], $prescription->loadCandidates[0]->contextHints()['positions']);
+        self::assertSame(['Deadlift'], $prescription->loadCandidates[1]->contextHints()['movements']);
+    }
+
+    public function testAddsTeamAudienceHintsToLoads(): void
+    {
+        $workout = $this->workout(
+            'Team Workout 4 Team Rx',
+            'FF/MM pairs. As many reps as possible in 15 minutes of: 30 deadlifts (FF) at 205-lb barbell, 30 deadlifts (MM) at 315-lb barbell.'
+        );
+
+        $prescription = (new WorkoutPrescriptionPatternInferer())->infer($workout);
+
+        self::assertCount(2, $prescription->loads);
+        self::assertSame('ff', $prescription->loads[0]->audienceHint);
+        self::assertSame('mm', $prescription->loads[1]->audienceHint);
+        self::assertSame('Deadlift', $prescription->loads[0]->movementHint);
+        self::assertSame(['ff'], $prescription->loadCandidates[0]->contextHints()['audiences']);
+        self::assertSame(['mm'], $prescription->loadCandidates[1]->contextHints()['audiences']);
+    }
+
     private function workout(string $name, string $flow): Workout
     {
         return new Workout(


### PR DESCRIPTION
## Summary
- add contextual fields to inferred load mentions: offset, nearText, positionLabel, audienceHint and movementHint
- aggregate candidate-level context hints for JSON reports
- infer barbell/medicine-ball/sled/etc. equipment from nearby movement text when no explicit implement is found

## Why
This makes the competition report useful for the next step: promoting reliable observed competition prescriptions into standards without losing whether a load was weight_1/weight_2, FF/MM, or tied to a movement like Deadlift.

## Validation
- php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutPrescriptionPatternInfererTest
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter 'WorkoutPrescriptionPatternInfererTest|InferWorkoutPrescriptionPatternsCommandTest'
- composer cs:check
- composer psalm
- git diff --check
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php bin/console app:workouts:infer-prescription-patterns --limit=1 --format=json --with-signal-only --env=test
