### PR TITLE
Refine workout load context inference

### DIFF
--- a/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
+++ b/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
@@ -214,18 +214,22 @@ final class WorkoutPrescriptionPatternInferer
 
     private function equipmentHint(string $text, int $offset, int $length): string
     {
+        $explicitHint = $this->explicitEquipmentHint($text, $offset, $length);
+        if ($explicitHint !== null) {
+            return $explicitHint;
+        }
+
+        $movementHint = $this->movementHint($text, $offset, $length);
+        if ($movementHint === 'Wall Ball Shot') {
+            return 'medicine ball';
+        }
+
         $windowStart = max(0, $offset - 48);
         $window = strtolower(substr($text, $windowStart, $length + 96));
         $loadCenter = $offset - $windowStart + (int) floor($length / 2);
 
         $hints = [
-            'dumbbell' => ['dumbbell', 'dumbbells', 'db'],
-            'kettlebell' => ['kettlebell', 'kettlebells', 'kb'],
             'barbell' => ['barbell', 'clean', 'snatch', 'deadlift', 'thruster', 'squat', 'jerk'],
-            'medicine ball' => ['medicine ball', 'wall ball'],
-            'sandbag' => ['sandbag'],
-            'sled' => ['sled'],
-            'vest' => ['vest', 'ruck'],
         ];
         $closestHint = null;
         $closestDistance = PHP_INT_MAX;
@@ -248,14 +252,26 @@ final class WorkoutPrescriptionPatternInferer
             return $closestHint;
         }
 
-        return match ($this->movementHint($text, $offset, $length)) {
+        return match ($movementHint) {
             'Deadlift', 'Clean', 'Clean and Jerk', 'Front Squat', 'Overhead Squat', 'Snatch', 'Thruster' => 'barbell',
-            'Wall Ball Shot' => 'medicine ball',
             'Farmer Carry' => 'kettlebell',
             'Sled Push', 'Sled Pull' => 'sled',
             'Walking Lunge' => 'sandbag',
             default => 'unknown',
         };
+    }
+
+    private function explicitEquipmentHint(string $text, int $offset, int $length): ?string
+    {
+        return $this->closestPatternLabel($text, $offset, $length, [
+            'medicine ball' => '/\b(?:medicine ball|med ball|wall[- ]ball|ball)\b/i',
+            'dumbbell' => '/\b(?:dumbbells?|dbs?)\b/i',
+            'kettlebell' => '/\b(?:kettlebells?|kbs?)\b/i',
+            'barbell' => '/\bbarbell\b/i',
+            'sandbag' => '/\bsand ?bag\b/i',
+            'sled' => '/\bsled\b/i',
+            'vest' => '/\b(?:vest|ruck)\b/i',
+        ], 72);
     }
 
     private function nearText(string $text, int $offset, int $length): string
@@ -268,14 +284,9 @@ final class WorkoutPrescriptionPatternInferer
 
     private function positionLabel(string $text, int $offset, int $length): ?string
     {
-        $weightPosition = $this->closestPatternLabel($text, $offset, $length, [
-            'weight_1' => '/\b(?:weight|load)\s*1\b/i',
-            'weight_2' => '/\b(?:weight|load)\s*2\b/i',
-            'weight_3' => '/\b(?:weight|load)\s*3\b/i',
-        ], 120);
-
-        if ($weightPosition !== null) {
-            return $weightPosition;
+        $weightPosition = $this->closestPatternMatch($text, $offset, $length, '/\b(?:weight|load)\s*(?P<number>\d+)\b/i', 120);
+        if ($weightPosition !== null && isset($weightPosition['number'])) {
+            return 'weight_'.$weightPosition['number'];
         }
 
         return $this->closestPatternLabel($text, $offset, $length, [
@@ -290,8 +301,8 @@ final class WorkoutPrescriptionPatternInferer
             'ff' => '/\bFF\b|\(FF\)/',
             'mm' => '/\bMM\b|\(MM\)/',
             'mixed' => '/\b(?:mixed|MF|FM)\b/',
-            'women' => '/\b(?:women|woman|female|girls?)\b/i',
-            'men' => '/\b(?:men|man|male|boys?)\b/i',
+            'women' => '/♀|\b(?:women|woman|female|girls?)\b/i',
+            'men' => '/♂|\b(?:men|man|male|boys?)\b/i',
             'team_pair' => '/\b(?:team|pairs?|partner|teammates?|synchronized)\b/i',
         ], 100);
     }
@@ -345,6 +356,40 @@ final class WorkoutPrescriptionPatternInferer
         }
 
         return $closestLabel;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function closestPatternMatch(string $text, int $offset, int $length, string $pattern, int $radius): ?array
+    {
+        $windowStart = max(0, $offset - $radius);
+        $window = substr($text, $windowStart, $length + ($radius * 2));
+        $loadCenter = $offset - $windowStart + (int) floor($length / 2);
+        $closestMatch = null;
+        $closestDistance = PHP_INT_MAX;
+
+        if (preg_match_all($pattern, $window, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE) < 1) {
+            return null;
+        }
+
+        foreach ($matches as $match) {
+            $position = (int) $match[0][1];
+            $distance = abs(($position + (int) floor(strlen($match[0][0]) / 2)) - $loadCenter);
+            if ($distance >= $closestDistance) {
+                continue;
+            }
+
+            $closestDistance = $distance;
+            $closestMatch = [];
+            foreach ($match as $key => $value) {
+                if (is_string($key)) {
+                    $closestMatch[$key] = $value[0];
+                }
+            }
+        }
+
+        return $closestMatch;
     }
 
     /**

--- a/tests/WorkoutPrescriptionPatternInfererTest.php
+++ b/tests/WorkoutPrescriptionPatternInfererTest.php
@@ -94,6 +94,57 @@ final class WorkoutPrescriptionPatternInfererTest extends TestCase
         self::assertSame(['mm'], $prescription->loadCandidates[1]->contextHints()['audiences']);
     }
 
+    public function testInfersGenderSymbolsAndGenericWeightPositions(): void
+    {
+        $workout = $this->workout(
+            'Workout 4',
+            'Max-reps clean and jerks in time remaining, weight 4. ♀ 165 lb (75 kg) ♂ 245 lb (111 kg).'
+        );
+
+        $prescription = (new WorkoutPrescriptionPatternInferer())->infer($workout);
+
+        self::assertCount(4, $prescription->loads);
+        self::assertSame('weight_4', $prescription->loads[0]->positionLabel);
+        self::assertSame('women', $prescription->loads[0]->audienceHint);
+        self::assertSame('men', $prescription->loads[2]->audienceHint);
+        self::assertSame('Clean and Jerk', $prescription->loads[2]->movementHint);
+        self::assertSame('barbell', $prescription->loads[3]->equipmentHint);
+    }
+
+    public function testPrefersExplicitImplementOverGenericBarbellMovementHint(): void
+    {
+        $workout = $this->workout(
+            'Team Workout 2 Team Rx',
+            'Alternating dumbbell snatches (all teammates synchronized). ♀ 50 lb ♀ 22.5 kg dumbbell. ♂ 70 lb ♂ 32.5 kg dumbbell.'
+        );
+
+        $prescription = (new WorkoutPrescriptionPatternInferer())->infer($workout);
+
+        self::assertCount(4, $prescription->loads);
+        foreach ($prescription->loads as $load) {
+            self::assertSame('dumbbell', $load->equipmentHint);
+            self::assertSame('Snatch', $load->movementHint);
+        }
+        self::assertSame('women', $prescription->loads[0]->audienceHint);
+        self::assertSame('men', $prescription->loads[2]->audienceHint);
+    }
+
+    public function testInfersMedicineBallFromBallTargetContext(): void
+    {
+        $workout = $this->workout(
+            'Team Workout 3 Team Rx',
+            '50 synchro wall-ball shots. ♀ 14-lb ball, 9-foot target. ♂ 20-lb ball, 10-foot target.'
+        );
+
+        $prescription = (new WorkoutPrescriptionPatternInferer())->infer($workout);
+
+        self::assertCount(2, $prescription->loads);
+        self::assertSame('medicine ball', $prescription->loads[0]->equipmentHint);
+        self::assertSame('Wall Ball Shot', $prescription->loads[0]->movementHint);
+        self::assertSame('women', $prescription->loads[0]->audienceHint);
+        self::assertSame('men', $prescription->loads[1]->audienceHint);
+    }
+
     private function workout(string $name, string $flow): Workout
     {
         return new Workout(


### PR DESCRIPTION
## Summary
- infer women/men audience hints from CrossFit symbols ♀ and ♂
- support generic weight/load positions such as weight_4 instead of stopping at weight_3
- prefer explicit nearby implements like dumbbell, ball, kettlebell or sled before falling back to movement-derived barbell hints

## Why
The production JSON showed useful context but also a few noisy cases: dumbbell snatches became barbell, wall-ball loads stayed unknown, and gender-symbol loads had no audience hint.

## Validation
- php -d memory_limit=1G bin/phpunit --colors=always --filter WorkoutPrescriptionPatternInfererTest
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter 'WorkoutPrescriptionPatternInfererTest|InferWorkoutPrescriptionPatternsCommandTest'
- composer cs:check
- composer psalm
- git diff --check
