### PR TITLE
Add observed prescription standards promotion

### DIFF
--- a/src/Command/PromoteObservedWorkoutPrescriptionStandardsCommand.php
+++ b/src/Command/PromoteObservedWorkoutPrescriptionStandardsCommand.php
@@ -1,0 +1,386 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Workout\Workout;
+use App\Entity\Workout\WorkoutPrescriptionStandard;
+use App\Services\Workout\Prescription\WorkoutLoadCandidate;
+use App\Services\Workout\Prescription\WorkoutLoadMention;
+use App\Services\Workout\Prescription\WorkoutPrescriptionPatternInferer;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:workouts:promote-observed-prescription-standards',
+    description: 'Promote reliable imported workout load signals into observed prescription standards.'
+)]
+final class PromoteObservedWorkoutPrescriptionStandardsCommand extends Command
+{
+    private const OBSERVED_SOURCE_NAME = 'crossfit_games_observed';
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly WorkoutPrescriptionPatternInferer $inferer,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('name', null, InputOption::VALUE_REQUIRED, 'Restrict the scan to one workout name.')
+            ->addOption('source', null, InputOption::VALUE_REQUIRED, 'Restrict the scan to one source name.', 'crossfit_games')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum number of workouts to scan.', 200)
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format: table or json.', 'table')
+            ->addOption('write', null, InputOption::VALUE_NONE, 'Persist promoted standards. Without this flag the command is a dry run.')
+            ->addOption('show-skipped', null, InputOption::VALUE_NONE, 'Include skipped candidates in the report.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $name = $this->stringOption($input->getOption('name'));
+        $source = $this->stringOption($input->getOption('source'));
+        $limit = max(1, (int) $input->getOption('limit'));
+        $format = $this->stringOption($input->getOption('format')) ?? 'table';
+        $write = (bool) $input->getOption('write');
+        $showSkipped = (bool) $input->getOption('show-skipped');
+
+        if (!in_array($format, ['table', 'json'], true)) {
+            $io->error('Invalid format. Use "table" or "json".');
+
+            return Command::INVALID;
+        }
+
+        $rows = [];
+        $stats = [
+            'scanned' => 0,
+            'promotable' => 0,
+            'created' => 0,
+            'existing' => 0,
+            'duplicates' => 0,
+            'skipped' => 0,
+        ];
+        $seenPayloadKeys = [];
+
+        foreach ($this->workouts($name, $source, $limit) as $workout) {
+            ++$stats['scanned'];
+            $prescription = $this->inferer->infer($workout);
+            foreach ($prescription->loadCandidates as $candidate) {
+                $standardPayload = $this->standardPayload($workout, $candidate, $prescription->levelHints);
+                if ($standardPayload === null) {
+                    ++$stats['skipped'];
+                    if ($showSkipped) {
+                        $rows[] = $this->row($workout, $candidate, 'skipped', null);
+                    }
+                    continue;
+                }
+
+                ++$stats['promotable'];
+                $payloadKey = $this->payloadKey($standardPayload);
+                if (isset($seenPayloadKeys[$payloadKey])) {
+                    ++$stats['duplicates'];
+                    $rows[] = $this->row($workout, $candidate, 'duplicate', $standardPayload);
+                    continue;
+                }
+                $seenPayloadKeys[$payloadKey] = true;
+
+                $existing = $this->existingStandard($standardPayload);
+                if ($existing instanceof WorkoutPrescriptionStandard) {
+                    ++$stats['existing'];
+                    $rows[] = $this->row($workout, $candidate, 'existing', $standardPayload);
+                    continue;
+                }
+
+                if ($write) {
+                    $this->entityManager->persist(new WorkoutPrescriptionStandard(...$standardPayload));
+                    ++$stats['created'];
+                    $rows[] = $this->row($workout, $candidate, 'created', $standardPayload);
+                    continue;
+                }
+
+                $rows[] = $this->row($workout, $candidate, 'would_create', $standardPayload);
+            }
+        }
+
+        if ($write) {
+            $this->entityManager->flush();
+        }
+
+        if ($format === 'json') {
+            $output->writeln(json_encode([
+                'dryRun' => !$write,
+                'stats' => $stats,
+                'standards' => $rows,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return Command::SUCCESS;
+        }
+
+        $io->title($write ? 'Observed prescription standards promotion' : 'Observed prescription standards dry run');
+        $io->definitionList(
+            ['scanned' => $stats['scanned']],
+            ['promotable' => $stats['promotable']],
+            ['created' => $stats['created']],
+            ['existing' => $stats['existing']],
+            ['duplicates' => $stats['duplicates']],
+            ['skipped' => $stats['skipped']],
+        );
+
+        if ($rows !== []) {
+            $table = new Table($output);
+            $table
+                ->setHeaders(['Status', 'Workout', 'Division', 'Movement', 'Implement', 'Load', 'Level', 'Candidate'])
+                ->setRows(array_map(static fn (array $row): array => [
+                    $row['status'],
+                    $row['workoutName'],
+                    $row['division'] ?? '-',
+                    $row['movementName'] ?? '-',
+                    $row['implementName'] ?? '-',
+                    $row['quantity'] === null ? '-' : $row['quantity'].' '.$row['unit'],
+                    $row['levelName'] ?? '-',
+                    $row['candidateLabel'],
+                ], $rows));
+            $table->render();
+        } else {
+            $io->note('No candidate matched the current filters.');
+        }
+
+        $io->note($write ? 'Promotion complete.' : 'Dry run only. Re-run with --write to persist.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return list<Workout>
+     */
+    private function workouts(?string $name, ?string $source, int $limit): array
+    {
+        $queryBuilder = $this->entityManager->getRepository(Workout::class)
+            ->createQueryBuilder('workout')
+            ->orderBy('workout.createdAt', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($name !== null) {
+            $queryBuilder
+                ->andWhere('LOWER(workout.name) LIKE LOWER(:name)')
+                ->setParameter('name', '%'.$name.'%');
+        }
+
+        if ($source !== null) {
+            $queryBuilder
+                ->andWhere('workout.sourceName = :source')
+                ->setParameter('source', $source);
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+
+    /**
+     * @param list<string> $levelHints
+     *
+     * @return array{
+     *     sourceName: string,
+     *     sport: string,
+     *     levelName: string|null,
+     *     division: string,
+     *     movementName: string|null,
+     *     implementName: string|null,
+     *     quantity: string,
+     *     unit: string,
+     *     quantityMultiplier: int,
+     *     contextLabel: string|null,
+     *     notes: string|null,
+     *     priority: int
+     * }|null
+     */
+    private function standardPayload(Workout $workout, WorkoutLoadCandidate $candidate, array $levelHints): ?array
+    {
+        if ($candidate->equipmentHint === 'unknown') {
+            return null;
+        }
+
+        $contextHints = $candidate->contextHints();
+        $audiences = array_values(array_unique(array_filter(array_map(
+            $this->normalizedAudience(...),
+            $contextHints['audiences'] ?? [],
+        ))));
+        if (count($audiences) !== 1) {
+            return null;
+        }
+
+        $movementName = count($contextHints['movements'] ?? []) === 1 ? $contextHints['movements'][0] : null;
+        $mention = $this->preferredMention($candidate);
+        if (!$mention instanceof WorkoutLoadMention || $mention->values === []) {
+            return null;
+        }
+
+        $values = array_values(array_unique($mention->values));
+        if (count($values) !== 1) {
+            return null;
+        }
+
+        $positionLabel = count($contextHints['positions'] ?? []) === 1 ? $contextHints['positions'][0] : null;
+
+        return [
+            'sourceName' => self::OBSERVED_SOURCE_NAME,
+            'sport' => 'crossfit',
+            'levelName' => $this->levelName($levelHints),
+            'division' => $audiences[0],
+            'movementName' => $movementName,
+            'implementName' => $candidate->equipmentHint,
+            'quantity' => $this->quantityString($values[0]),
+            'unit' => $mention->unit,
+            'quantityMultiplier' => count($mention->values),
+            'contextLabel' => $positionLabel,
+            'notes' => $this->notes($workout, $candidate),
+            'priority' => 80,
+        ];
+    }
+
+    private function preferredMention(WorkoutLoadCandidate $candidate): ?WorkoutLoadMention
+    {
+        if ($candidate->kind === 'conversion') {
+            foreach ($candidate->mentions as $mention) {
+                if ($mention->unit === 'kg') {
+                    return $mention;
+                }
+            }
+        }
+
+        return $candidate->mentions[0] ?? null;
+    }
+
+    /**
+     * @param list<string> $levelHints
+     */
+    private function levelName(array $levelHints): ?string
+    {
+        foreach (['elite', 'rx', 'scaled', 'intermediate', 'beginner', 'masters', 'teen'] as $level) {
+            if (in_array($level, $levelHints, true)) {
+                return $level === 'rx' ? 'RX' : ucfirst($level);
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizedAudience(string $audience): ?string
+    {
+        return match ($audience) {
+            'women', 'ff' => 'women',
+            'men', 'mm' => 'men',
+            default => null,
+        };
+    }
+
+    /**
+     * @param array{
+     *     sourceName: string,
+     *     sport: string,
+     *     levelName: string|null,
+     *     division: string,
+     *     movementName: string|null,
+     *     implementName: string|null,
+     *     quantity: string,
+     *     unit: string,
+     *     quantityMultiplier: int,
+     *     contextLabel: string|null,
+     *     notes: string|null,
+     *     priority: int
+     * } $payload
+     */
+    private function existingStandard(array $payload): ?WorkoutPrescriptionStandard
+    {
+        return $this->entityManager->getRepository(WorkoutPrescriptionStandard::class)->findOneBy([
+            'sourceName' => $payload['sourceName'],
+            'sport' => $payload['sport'],
+            'levelName' => $payload['levelName'],
+            'division' => $payload['division'],
+            'movementName' => $payload['movementName'],
+            'implementName' => $payload['implementName'],
+            'quantity' => $payload['quantity'],
+            'unit' => $payload['unit'],
+            'quantityMultiplier' => $payload['quantityMultiplier'],
+            'contextLabel' => $payload['contextLabel'],
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed>|null $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function row(
+        Workout $workout,
+        WorkoutLoadCandidate $candidate,
+        string $status,
+        ?array $payload,
+    ): array {
+        return [
+            'status' => $status,
+            'workoutName' => $workout->getName(),
+            'sourceName' => $workout->getSourceName(),
+            'externalId' => $workout->getExternalId(),
+            'division' => $payload['division'] ?? null,
+            'movementName' => $payload['movementName'] ?? null,
+            'implementName' => $payload['implementName'] ?? null,
+            'quantity' => $payload['quantity'] ?? null,
+            'unit' => $payload['unit'] ?? null,
+            'levelName' => $payload['levelName'] ?? null,
+            'contextLabel' => $payload['contextLabel'] ?? null,
+            'candidateLabel' => $candidate->label(),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function payloadKey(array $payload): string
+    {
+        return implode('|', array_map(
+            static fn (mixed $value): string => $value === null ? '' : (string) $value,
+            [
+                $payload['sourceName'],
+                $payload['sport'],
+                $payload['levelName'],
+                $payload['division'],
+                $payload['movementName'],
+                $payload['implementName'],
+                $payload['quantity'],
+                $payload['unit'],
+                $payload['quantityMultiplier'],
+                $payload['contextLabel'],
+            ],
+        ));
+    }
+
+    private function notes(Workout $workout, WorkoutLoadCandidate $candidate): string
+    {
+        return substr(implode(' | ', array_filter([
+            $workout->getName(),
+            $workout->getExternalId(),
+            $candidate->label(),
+        ])), 0, 255);
+    }
+
+    private function quantityString(float $quantity): string
+    {
+        return number_format($quantity, 2, '.', '');
+    }
+
+    private function stringOption(mixed $value): ?string
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        return trim($value);
+    }
+}

--- a/tests/InferWorkoutPrescriptionPatternsCommandTest.php
+++ b/tests/InferWorkoutPrescriptionPatternsCommandTest.php
@@ -3,6 +3,12 @@
 namespace App\Tests;
 
 use App\Command\InferWorkoutPrescriptionPatternsCommand;
+use App\Command\PromoteObservedWorkoutPrescriptionStandardsCommand;
+use App\Entity\Workout\Enum\WorkoutOriginNameEnum;
+use App\Entity\Workout\Workout;
+use App\Entity\Workout\WorkoutOrigin;
+use App\Entity\Workout\WorkoutOriginName;
+use App\Entity\Workout\WorkoutPrescriptionStandard;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class InferWorkoutPrescriptionPatternsCommandTest extends AbstractIntegrationTest
@@ -16,5 +22,76 @@ final class InferWorkoutPrescriptionPatternsCommandTest extends AbstractIntegrat
         self::assertStringContainsString('Workout prescription pattern report', $tester->getDisplay());
         self::assertStringContainsString('Handstand Push Up', $tester->getDisplay());
         self::assertStringContainsString('rings', $tester->getDisplay());
+    }
+
+    public function testObservedStandardsPromotionDryRunDoesNotPersist(): void
+    {
+        $this->persistObservedWorkout();
+
+        $tester = new CommandTester($this->getService(PromoteObservedWorkoutPrescriptionStandardsCommand::class));
+        $exitCode = $tester->execute([
+            '--name' => 'Observed 24.1',
+            '--limit' => 1,
+            '--format' => 'json',
+        ]);
+
+        self::assertSame(0, $exitCode);
+        $payload = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertTrue($payload['dryRun']);
+        self::assertSame(2, $payload['stats']['promotable']);
+        self::assertSame('would_create', $payload['standards'][0]['status']);
+        self::assertSame('women', $payload['standards'][0]['division']);
+        self::assertSame('dumbbell', $payload['standards'][0]['implementName']);
+        self::assertSame('15.00', $payload['standards'][0]['quantity']);
+
+        self::assertCount(0, $this->getRepository(WorkoutPrescriptionStandard::class)->findBy([
+            'sourceName' => 'crossfit_games_observed',
+        ]));
+    }
+
+    public function testObservedStandardsPromotionWritesAndSkipsDuplicates(): void
+    {
+        $this->persistObservedWorkout();
+
+        $tester = new CommandTester($this->getService(PromoteObservedWorkoutPrescriptionStandardsCommand::class));
+        $exitCode = $tester->execute([
+            '--name' => 'Observed 24.1',
+            '--limit' => 1,
+            '--write' => true,
+        ]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('created', $tester->getDisplay());
+
+        $tester = new CommandTester($this->getService(PromoteObservedWorkoutPrescriptionStandardsCommand::class));
+        $exitCode = $tester->execute([
+            '--name' => 'Observed 24.1',
+            '--limit' => 1,
+            '--write' => true,
+        ]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('existing', $tester->getDisplay());
+        $standards = $this->getRepository(WorkoutPrescriptionStandard::class)->findBy([
+            'sourceName' => 'crossfit_games_observed',
+        ]);
+        self::assertCount(2, $standards);
+    }
+
+    private function persistObservedWorkout(): void
+    {
+        $workout = (new Workout(
+            'Observed 24.1',
+            'For time: 21 dumbbell snatches, arm 1. Time cap: 15 minutes ♀ 35-lb (15-kg) dumbbell ♂ 50-lb (22.5-kg) dumbbell',
+            1,
+            15,
+            null,
+            new WorkoutOrigin(new WorkoutOriginName(WorkoutOriginNameEnum::CROSSFIT_OPEN_WORKOUT), 2024),
+        ))
+            ->setSourceName('crossfit_games')
+            ->setExternalId('observed-24-1');
+
+        $this->getEntityManager()->persist($workout);
+        $this->getEntityManager()->flush();
     }
 }


### PR DESCRIPTION
## Summary
- add a dry-run-first command to promote reliable inferred load candidates into observed prescription standards
- persist only scoped men/women standards with known equipment, preferred kg conversions, duplicate protection, and optional --write
- cover dry-run, write, and duplicate-skip behavior in command tests

## Tests
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter 'WorkoutPrescriptionPatternInfererTest|InferWorkoutPrescriptionPatternsCommandTest'
- composer cs:check
- composer psalm
- git diff --check