### PR TITLE
Tighten observed prescription promotion filters

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -14378,16 +14378,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.24.0",
+            "version": "v3.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0"
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6769aefb305efef849dc25c9fd1653358c148f0",
-                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
                 "shasum": ""
             },
             "require": {
@@ -14442,7 +14442,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.24.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
             },
             "funding": [
                 {
@@ -14454,7 +14454,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-17T21:31:11+00:00"
+            "time": "2026-05-20T07:31:59+00:00"
         },
         {
             "name": "vimeo/psalm",

--- a/src/Command/PromoteObservedWorkoutPrescriptionStandardsCommand.php
+++ b/src/Command/PromoteObservedWorkoutPrescriptionStandardsCommand.php
@@ -202,6 +202,10 @@ final class PromoteObservedWorkoutPrescriptionStandardsCommand extends Command
      */
     private function standardPayload(Workout $workout, WorkoutLoadCandidate $candidate, array $levelHints): ?array
     {
+        if ($candidate->kind !== 'conversion') {
+            return null;
+        }
+
         if ($candidate->equipmentHint === 'unknown') {
             return null;
         }
@@ -216,6 +220,10 @@ final class PromoteObservedWorkoutPrescriptionStandardsCommand extends Command
         }
 
         $movementName = count($contextHints['movements'] ?? []) === 1 ? $contextHints['movements'][0] : null;
+        if ($movementName === null || !$this->isCompatibleMovement($candidate->equipmentHint, $movementName)) {
+            return null;
+        }
+
         $mention = $this->preferredMention($candidate);
         if (!$mention instanceof WorkoutLoadMention || $mention->values === []) {
             return null;
@@ -269,6 +277,45 @@ final class PromoteObservedWorkoutPrescriptionStandardsCommand extends Command
         }
 
         return null;
+    }
+
+    private function isCompatibleMovement(string $equipmentHint, string $movementName): bool
+    {
+        $compatibleMovements = [
+            'barbell' => [
+                'Clean',
+                'Clean and Jerk',
+                'Deadlift',
+                'Front Squat',
+                'Hang Power Clean',
+                'Overhead Squat',
+                'Snatch',
+                'Squat Clean',
+                'Thruster',
+            ],
+            'dumbbell' => [
+                'Clean',
+                'Farmer Carry',
+                'Snatch',
+                'Walking Lunge',
+            ],
+            'kettlebell' => [
+                'Farmer Carry',
+                'Walking Lunge',
+            ],
+            'medicine ball' => [
+                'Wall Ball Shot',
+            ],
+            'sled' => [
+                'Sled Pull',
+                'Sled Push',
+            ],
+            'sandbag' => [
+                'Walking Lunge',
+            ],
+        ];
+
+        return in_array($movementName, $compatibleMovements[$equipmentHint] ?? [], true);
     }
 
     private function normalizedAudience(string $audience): ?string


### PR DESCRIPTION
## Summary
- only promote conversion candidates into observed prescription standards
- require a single inferred movement before promotion
- skip candidates whose movement is incompatible with the inferred equipment, e.g. medicine ball + Box Jump or single-load medicine-ball noise

## Tests
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter 'WorkoutPrescriptionPatternInfererTest|InferWorkoutPrescriptionPatternsCommandTest'
- composer cs:check
- composer psalm
- git diff --check