### PR TITLE
Reduce observed promotion duplicate noise

### DIFF
--- a/src/Command/PromoteObservedWorkoutPrescriptionStandardsCommand.php
+++ b/src/Command/PromoteObservedWorkoutPrescriptionStandardsCommand.php
@@ -39,6 +39,7 @@ final class PromoteObservedWorkoutPrescriptionStandardsCommand extends Command
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum number of workouts to scan.', 200)
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Output format: table or json.', 'table')
             ->addOption('write', null, InputOption::VALUE_NONE, 'Persist promoted standards. Without this flag the command is a dry run.')
+            ->addOption('show-duplicates', null, InputOption::VALUE_NONE, 'Include duplicate candidates in the report.')
             ->addOption('show-skipped', null, InputOption::VALUE_NONE, 'Include skipped candidates in the report.');
     }
 
@@ -50,6 +51,7 @@ final class PromoteObservedWorkoutPrescriptionStandardsCommand extends Command
         $limit = max(1, (int) $input->getOption('limit'));
         $format = $this->stringOption($input->getOption('format')) ?? 'table';
         $write = (bool) $input->getOption('write');
+        $showDuplicates = (bool) $input->getOption('show-duplicates');
         $showSkipped = (bool) $input->getOption('show-skipped');
 
         if (!in_array($format, ['table', 'json'], true)) {
@@ -86,7 +88,9 @@ final class PromoteObservedWorkoutPrescriptionStandardsCommand extends Command
                 $payloadKey = $this->payloadKey($standardPayload);
                 if (isset($seenPayloadKeys[$payloadKey])) {
                     ++$stats['duplicates'];
-                    $rows[] = $this->row($workout, $candidate, 'duplicate', $standardPayload);
+                    if ($showDuplicates) {
+                        $rows[] = $this->row($workout, $candidate, 'duplicate', $standardPayload);
+                    }
                     continue;
                 }
                 $seenPayloadKeys[$payloadKey] = true;

--- a/tests/InferWorkoutPrescriptionPatternsCommandTest.php
+++ b/tests/InferWorkoutPrescriptionPatternsCommandTest.php
@@ -78,10 +78,41 @@ final class InferWorkoutPrescriptionPatternsCommandTest extends AbstractIntegrat
         self::assertCount(2, $standards);
     }
 
-    private function persistObservedWorkout(): void
+    public function testObservedStandardsPromotionHidesDuplicateRowsUnlessRequested(): void
+    {
+        $this->persistObservedWorkout();
+        $this->persistObservedWorkout('Observed 24.1 Repeat', 'observed-24-1-repeat');
+
+        $tester = new CommandTester($this->getService(PromoteObservedWorkoutPrescriptionStandardsCommand::class));
+        $exitCode = $tester->execute([
+            '--name' => 'Observed 24.1',
+            '--limit' => 2,
+            '--format' => 'json',
+        ]);
+
+        self::assertSame(0, $exitCode);
+        $payload = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(4, $payload['stats']['promotable']);
+        self::assertSame(2, $payload['stats']['duplicates']);
+        self::assertSame(['would_create', 'would_create'], array_column($payload['standards'], 'status'));
+
+        $tester = new CommandTester($this->getService(PromoteObservedWorkoutPrescriptionStandardsCommand::class));
+        $exitCode = $tester->execute([
+            '--name' => 'Observed 24.1',
+            '--limit' => 2,
+            '--format' => 'json',
+            '--show-duplicates' => true,
+        ]);
+
+        self::assertSame(0, $exitCode);
+        $payload = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['would_create', 'would_create', 'duplicate', 'duplicate'], array_column($payload['standards'], 'status'));
+    }
+
+    private function persistObservedWorkout(string $name = 'Observed 24.1', string $externalId = 'observed-24-1'): void
     {
         $workout = (new Workout(
-            'Observed 24.1',
+            $name,
             'For time: 21 dumbbell snatches, arm 1. Time cap: 15 minutes ♀ 35-lb (15-kg) dumbbell ♂ 50-lb (22.5-kg) dumbbell',
             1,
             15,
@@ -89,7 +120,7 @@ final class InferWorkoutPrescriptionPatternsCommandTest extends AbstractIntegrat
             new WorkoutOrigin(new WorkoutOriginName(WorkoutOriginNameEnum::CROSSFIT_OPEN_WORKOUT), 2024),
         ))
             ->setSourceName('crossfit_games')
-            ->setExternalId('observed-24-1');
+            ->setExternalId($externalId);
 
         $this->getEntityManager()->persist($workout);
         $this->getEntityManager()->flush();


### PR DESCRIPTION
## Summary
- hide duplicate candidate rows by default in observed prescription promotion reports
- keep duplicate stats intact and add --show-duplicates for full diagnostics
- cover default and opt-in duplicate reporting in command tests

## Verification
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter InferWorkoutPrescriptionPatternsCommandTest
- composer cs:check
- composer psalm
- git diff --check

## Note
- composer audit could not complete locally because DNS resolution for packagist.org failed.