### PR TITLE
Avoid promoting dumbbell step-up loads as snatches

### DIFF
--- a/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
+++ b/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
@@ -465,6 +465,10 @@ final class WorkoutPrescriptionPatternInferer
             $explicitEquipmentHint === 'dumbbell'
             && preg_match('/\bsnatch(?:es)?\b/i', $nearText) === 1
         ) {
+            if ($this->looksLikeDumbbellBoxStepUpLoadContext($text, $offset, $length)) {
+                return null;
+            }
+
             return 'Snatch';
         }
 
@@ -500,6 +504,13 @@ final class WorkoutPrescriptionPatternInferer
         }
 
         return preg_match('/\bwall[- ]ball(?: shots?)?\b/i', substr($text, max(0, $offset - 220), $length + 260)) === 1;
+    }
+
+    private function looksLikeDumbbellBoxStepUpLoadContext(string $text, int $offset, int $length): bool
+    {
+        $loadContext = substr($text, max(0, $offset - 220), $length + 300);
+
+        return preg_match('/\b(?:dumbbell\s+)?box\s+step[- ]ups?\b/i', $loadContext) === 1;
     }
 
     /**

--- a/tests/WorkoutPrescriptionPatternInfererTest.php
+++ b/tests/WorkoutPrescriptionPatternInfererTest.php
@@ -176,12 +176,16 @@ final class WorkoutPrescriptionPatternInfererTest extends TestCase
         self::assertCount(8, $prescription->loads);
         self::assertSame('women', $prescription->loads[2]->audienceHint);
         self::assertSame('dumbbell', $prescription->loads[2]->equipmentHint);
+        self::assertNull($prescription->loads[2]->movementHint);
         self::assertSame('women', $prescription->loads[3]->audienceHint);
         self::assertSame('dumbbell', $prescription->loads[3]->equipmentHint);
+        self::assertNull($prescription->loads[3]->movementHint);
         self::assertSame('men', $prescription->loads[6]->audienceHint);
         self::assertSame('dumbbell', $prescription->loads[6]->equipmentHint);
+        self::assertNull($prescription->loads[6]->movementHint);
         self::assertSame('men', $prescription->loads[7]->audienceHint);
         self::assertSame('dumbbell', $prescription->loads[7]->equipmentHint);
+        self::assertNull($prescription->loads[7]->movementHint);
     }
 
     public function testDoesNotLetLaterDumbbellTextOverrideImmediateBarbellClause(): void


### PR DESCRIPTION
## Summary
- keep dumbbell loads near dumbbell box step-up context from inheriting Snatch movement hints
- preserve equipment and audience hints for compact gender load segments
- cover the grouped barbell/dumbbell load case in prescription inference tests

## Verification
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter 'WorkoutPrescriptionPatternInfererTest|InferWorkoutPrescriptionPatternsCommandTest'
- composer cs:check
- composer psalm
- git diff --check

## Note
- composer audit could not complete locally because DNS resolution for Packagist timed out.