### PR TITLE
Keep dumbbell step-up conversions out of snatch standards

### DIFF
--- a/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
+++ b/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
@@ -472,6 +472,13 @@ final class WorkoutPrescriptionPatternInferer
             return 'Snatch';
         }
 
+        if (
+            $this->loadContextLooksLikeDumbbell($text, $offset)
+            && $this->looksLikeDumbbellBoxStepUpLoadContext($text, $offset, $length)
+        ) {
+            return null;
+        }
+
         return $this->closestPatternLabel($text, $offset, $length, [
             'Clean and Jerk' => '/\bclean(?:s)? and jerk(?:s)?\b/i',
             'Hang Power Clean' => '/\bhang power clean(?:s)?\b/i',
@@ -511,6 +518,14 @@ final class WorkoutPrescriptionPatternInferer
         $loadContext = substr($text, max(0, $offset - 220), $length + 300);
 
         return preg_match('/\b(?:dumbbell\s+)?box\s+step[- ]ups?\b/i', $loadContext) === 1;
+    }
+
+    private function loadContextLooksLikeDumbbell(string $text, int $offset): bool
+    {
+        return preg_match(
+            '/\b(?:dumbbells?|dbs?)\b/i',
+            $this->loadClause($text, $offset).' '.$this->afterLoadClause($text, $offset),
+        ) === 1;
     }
 
     /**

--- a/tests/InferWorkoutPrescriptionPatternsCommandTest.php
+++ b/tests/InferWorkoutPrescriptionPatternsCommandTest.php
@@ -109,11 +109,38 @@ final class InferWorkoutPrescriptionPatternsCommandTest extends AbstractIntegrat
         self::assertSame(['would_create', 'would_create', 'duplicate', 'duplicate'], array_column($payload['standards'], 'status'));
     }
 
-    private function persistObservedWorkout(string $name = 'Observed 24.1', string $externalId = 'observed-24-1'): void
+    public function testObservedStandardsPromotionSkipsConversionWhenMovementHintsAreIncomplete(): void
     {
+        $this->persistObservedWorkout(
+            'Observed box step-ups',
+            'observed-box-step-ups',
+            '4 rounds for max reps of: 1 minute of snatches, 1 minute of rowing for calories, 1 minute of dumbbell box step-ups, 1 minute of rest. ♀ 85-lb (38 kg) barbell, 35-lb (15 kg) dumbbells, 20-inch box ♂ 135-lb (61kg) barbell, 50-lb (22.5 kg) dumbbells, 20-inch box',
+        );
+
+        $tester = new CommandTester($this->getService(PromoteObservedWorkoutPrescriptionStandardsCommand::class));
+        $exitCode = $tester->execute([
+            '--name' => 'Observed box step-ups',
+            '--limit' => 1,
+            '--format' => 'json',
+        ]);
+
+        self::assertSame(0, $exitCode);
+        $payload = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(1, $payload['stats']['promotable']);
+        self::assertSame(3, $payload['stats']['skipped']);
+        self::assertSame(['would_create'], array_column($payload['standards'], 'status'));
+        self::assertSame('barbell', $payload['standards'][0]['implementName']);
+        self::assertSame('Snatch', $payload['standards'][0]['movementName']);
+    }
+
+    private function persistObservedWorkout(
+        string $name = 'Observed 24.1',
+        string $externalId = 'observed-24-1',
+        string $flow = 'For time: 21 dumbbell snatches, arm 1. Time cap: 15 minutes ♀ 35-lb (15-kg) dumbbell ♂ 50-lb (22.5-kg) dumbbell',
+    ): void {
         $workout = (new Workout(
             $name,
-            'For time: 21 dumbbell snatches, arm 1. Time cap: 15 minutes ♀ 35-lb (15-kg) dumbbell ♂ 50-lb (22.5-kg) dumbbell',
+            $flow,
             1,
             15,
             null,

--- a/tests/WorkoutPrescriptionPatternInfererTest.php
+++ b/tests/WorkoutPrescriptionPatternInfererTest.php
@@ -177,6 +177,8 @@ final class WorkoutPrescriptionPatternInfererTest extends TestCase
         self::assertSame('women', $prescription->loads[2]->audienceHint);
         self::assertSame('dumbbell', $prescription->loads[2]->equipmentHint);
         self::assertNull($prescription->loads[2]->movementHint);
+        self::assertSame('35 lb ~= 15 kg dumbbell conversion', $prescription->loadCandidates[1]->label());
+        self::assertSame([], $prescription->loadCandidates[1]->contextHints()['movements']);
         self::assertSame('women', $prescription->loads[3]->audienceHint);
         self::assertSame('dumbbell', $prescription->loads[3]->equipmentHint);
         self::assertNull($prescription->loads[3]->movementHint);


### PR DESCRIPTION
## Summary
- prevent generic movement fallback from tagging dumbbell box step-up loads as Snatch
- assert the 35 lb / 15 kg dumbbell conversion carries no movement context in the grouped Workout 1 case
- add promotion coverage showing only the barbell snatch standard remains promotable for that workout shape

## Verification
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter 'WorkoutPrescriptionPatternInfererTest|InferWorkoutPrescriptionPatternsCommandTest'
- composer cs:check
- composer psalm
- git diff --check

## Note
- composer audit could not complete locally because DNS resolution for Packagist timed out.