### PR TITLE
Infer comma separated load ladders

### DIFF
--- a/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
+++ b/src/Services/Workout/Prescription/WorkoutPrescriptionPatternInferer.php
@@ -9,6 +9,7 @@ use App\Entity\Workout\Workout;
 final class WorkoutPrescriptionPatternInferer
 {
     private const LOAD_PATTERN = '/(?<![a-z0-9])(?P<first>\d+(?:[\.,]\d+)?)\s*(?:\/|and|or|&)\s*(?P<second>\d+(?:[\.,]\d+)?)\s*(?P<unit>kg|kgs|kilograms?|lb|lbs|pounds?)(?![a-z])/i';
+    private const LOAD_LIST_PATTERN = '/(?<![a-z0-9])(?P<values>\d+(?:[\.,]\d+)?(?:\s*,\s*\d+(?:[\.,]\d+)?){2,})\s*(?P<unit>kg|kgs|kilograms?|lb|lbs|pounds?)(?![a-z])/i';
     private const SINGLE_LOAD_PATTERN = '/(?<![a-z0-9])(?:(?P<count>\d+)\s*x\s*)?(?P<value>\d+(?:[\.,]\d+)?)\s*-?\s*(?P<unit>kg|kgs|kilograms?|lb|lbs|pounds?)(?![a-z])/i';
 
     public function infer(Workout $workout): InferredWorkoutPrescription
@@ -139,6 +140,27 @@ final class WorkoutPrescriptionPatternInferer
     {
         $loads = [];
         $seen = [];
+        $skipSingleLoadRanges = [];
+
+        if (preg_match_all(self::LOAD_LIST_PATTERN, $text, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
+            foreach ($matches as $match) {
+                $raw = $match[0][0];
+                $offset = (int) $match[0][1];
+                $load = new WorkoutLoadMention(
+                    $raw,
+                    array_map($this->floatValue(...), preg_split('/\s*,\s*/', $match['values'][0]) ?: []),
+                    $this->unit($match['unit'][0]),
+                    $this->equipmentHint($text, $offset, strlen($raw)),
+                    $offset,
+                    $this->nearText($text, $offset, strlen($raw)),
+                    $this->positionLabel($text, $offset, strlen($raw)),
+                    $this->audienceHint($text, $offset, strlen($raw)),
+                    $this->movementHint($text, $offset, strlen($raw)),
+                );
+                $this->addLoad($loads, $seen, $load);
+                $skipSingleLoadRanges[] = [$offset, $offset + strlen($raw)];
+            }
+        }
 
         if (preg_match_all(self::LOAD_PATTERN, $text, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
             foreach ($matches as $match) {
@@ -162,6 +184,10 @@ final class WorkoutPrescriptionPatternInferer
             foreach ($matches as $match) {
                 $raw = $match[0][0];
                 $offset = (int) $match[0][1];
+
+                if ($this->isInsideAnyRange($offset, $skipSingleLoadRanges)) {
+                    continue;
+                }
 
                 if ($this->isPartOfPairedLoad($text, $offset, strlen($raw))) {
                     continue;
@@ -188,6 +214,20 @@ final class WorkoutPrescriptionPatternInferer
         }
 
         return $loads;
+    }
+
+    /**
+     * @param list<array{0: int, 1: int}> $ranges
+     */
+    private function isInsideAnyRange(int $offset, array $ranges): bool
+    {
+        foreach ($ranges as [$start, $end]) {
+            if ($offset >= $start && $offset < $end) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/WorkoutPrescriptionPatternInfererTest.php
+++ b/tests/WorkoutPrescriptionPatternInfererTest.php
@@ -58,6 +58,24 @@ final class WorkoutPrescriptionPatternInfererTest extends TestCase
         self::assertSame('115 lb ~= 52 kg barbell conversion', $prescription->loadCandidates[1]->label());
     }
 
+    public function testInfersCommaSeparatedLoadLaddersAsOneConversionCandidate(): void
+    {
+        $workout = $this->workout(
+            'Age-Group Quarterfinals Workout 3 Men (35-39) Rx',
+            'For time: 3 rounds of 50 double-unders and 10 deadlifts, weight 3 (heaviest). Time cap: 12 minutes ♀ 155, 185, 225 lb (70, 83, 102 kg) ♂ 225, 275, 315 lb (102, 125, 143 kg)'
+        );
+
+        $prescription = (new WorkoutPrescriptionPatternInferer())->infer($workout);
+
+        self::assertSame([155.0, 185.0, 225.0], $prescription->loads[0]->values);
+        self::assertSame([70.0, 83.0, 102.0], $prescription->loads[1]->values);
+        self::assertSame('155/185/225 lb ~= 70/83/102 kg barbell conversion', $prescription->loadCandidates[0]->label());
+        self::assertSame(['weight_3'], $prescription->loadCandidates[0]->contextHints()['positions']);
+        self::assertSame(['women'], $prescription->loadCandidates[0]->contextHints()['audiences']);
+        self::assertSame(['Deadlift'], $prescription->loadCandidates[0]->contextHints()['movements']);
+        self::assertSame('225/275/315 lb ~= 102/125/143 kg barbell conversion', $prescription->loadCandidates[1]->label());
+    }
+
     public function testAddsContextHintsToWeightPositionLoads(): void
     {
         $workout = $this->workout(


### PR DESCRIPTION
## Summary
- detect comma-separated load ladders such as 155, 185, 225 lb as one load mention
- pair those grouped lb values with grouped kg conversions
- avoid emitting duplicate single-load mentions inside the grouped list

## Verification
- DATABASE_URL='postgresql://app:!ChangeMe!@127.0.0.1:5432/crossfit?serverVersion=16&charset=utf8' php -d memory_limit=1G bin/phpunit --colors=always --filter 'WorkoutPrescriptionPatternInfererTest|InferWorkoutPrescriptionPatternsCommandTest'
- composer cs:check
- composer psalm
- git diff --check

## Note
- composer audit could not complete locally because DNS resolution for Packagist timed out.